### PR TITLE
Update Meshtastic.h

### DIFF
--- a/src/Meshtastic.h
+++ b/src/Meshtastic.h
@@ -73,7 +73,7 @@ typedef enum {
 bool mt_request_node_report(void (*callback)(mt_node_t *, mt_nr_progress_t));
 
 // Set the callback function that gets called when the node receives a text message.
-void set_text_message_callback(void (*callback)(uint32_t from, const char * text));
+void set_text_message_callback(void (*callback)(uint32_t from, const char* text, uint8_t channel));
 
 // Send a text message with *text* as payload, to a destination node (optional), on a certain channel (optional).
 bool mt_send_text(const char * text, uint32_t dest = BROADCAST_ADDR, uint8_t channel_index = 0);


### PR DESCRIPTION
Yes, you can retrieve the channel information without modifying the library by adding a callback for processing text messages in your program. Here's how you can do it:

1. **Define a callback for processing text messages**:
    - This callback will be called every time a text message is received.
    - It can record the channel and any other relevant information.

2. **Configure the library to use this callback**:
    - Use `set_text_message_callback` to record your callback.

3. **Use the callback to store the index of the last channel**:
    - In the callback, store the channel index in a global variable or a class member (if using a class).

Here is an example illustrating this approach:

```c
#include <Meshtastic.h>

// Définir une variable globale pour stocker l'index du dernier canal
uint8_t last_channel_index = 0;

// Définir une fonction de callback pour le traitement des messages textuels
void my_text_message_callback(uint32_t from, const char* text, uint8_t channel) {
    // Stocker l'index du canal
    last_channel_index = channel;
    // Traiter le message texte comme vous le souhaitez
    Serial.print("Received message from ");
    Serial.print(from);
    Serial.print(" on channel ");
    Serial.print(channel);
    Serial.print(": ");
    Serial.println(text);
}

void setup() {
    // Initialiser la communication série
    Serial.begin(115200);

    // Initialiser la bibliothèque Meshtastic
    // Assurez-vous d'appeler les fonctions d'initialisation nécessaires ici

    // Configurer le callback pour les messages textuels
    set_text_message_callback(my_text_message_callback);
}

void loop() {
    // Appeler la fonction mt_loop régulièrement
    mt_loop(millis());

    // Exemple d'utilisation de last_channel_index
    // Vous pouvez l'utiliser ici ou ailleurs dans votre programme
    Serial.print("Last channel index: ");
    Serial.println(last_channel_index);

    // Autres tâches dans la boucle principale
    delay(1000);
}
```


### Modification of the callback function in the library

You need to slightly modify the `set_text_message_callback` callback function in the “mt_protocol.cpp” library to pass the channel index to the user callback. It might look like this:

#### Modification of the callback function in the library:

```c
void (*text_message_callback)(uint32_t from, const char* text, uint8_t channel) = NULL;

void set_text_message_callback(void (*callback)(uint32_t from, const char* text, uint8_t channel)) {
  text_message_callback = callback;
}
```

#### Modified `handle_mesh_packet` to include channel:

```c
bool handle_mesh_packet(meshtastic_MeshPacket *meshPacket) {
  if (meshPacket->which_payload_variant == meshtastic_MeshPacket_decoded_tag) {
    if (meshPacket->decoded.portnum == meshtastic_PortNum_TEXT_MESSAGE_APP) {
      if (text_message_callback != NULL) {
        text_message_callback(meshPacket->from, (const char*)meshPacket->decoded.payload.bytes, meshPacket->channel);
      }
    } else {
      // TODO handle other portnums
      return false;
    }
  } else {
    return false;
  }
  return true;
}
```

With these changes, your `my_text_message_callback` callback will receive the channel index every time a text message is received, and you will be able to use this information in your main program without touching the library further.
Don’t forget to also modify “meshtastic.h”
Line 75
// Set the callback function that gets called when the node receives a text message.
void set_text_message_callback(void (*callback)(uint32_t from, const char* text, uint8_t channel));