### PR TITLE
Add function to catch DM's to the receiver

### DIFF
--- a/examples/SendReceiveClient/SendReceiveClient.ino
+++ b/examples/SendReceiveClient/SendReceiveClient.ino
@@ -47,8 +47,12 @@ void text_message_callback(uint32_t from, uint32_t to, const char* text) {
   Serial.print(to);
   Serial.print(" message: ");
   Serial.println(text);
-  if (to == my_node_num){
+  if (to == 0xFFFFFFFF){
+    Serial.println("This is a BROADCAST message.");
+  } else if (to == my_node_num){
     Serial.println("This is a DM to me!");
+  } else {
+    Serial.println("This is a DM to someone else.");
   }
 }
 
@@ -85,7 +89,7 @@ void setup() {
   mt_request_node_report(connected_callback);
 
   // Register a callback function to be called whenever a text message is received
-  set_directed_text_message_callback(text_message_callback);
+  set_text_message_callback(text_message_callback);
 }
 
 void loop() {

--- a/examples/SendReceiveClient/SendReceiveClient.ino
+++ b/examples/SendReceiveClient/SendReceiveClient.ino
@@ -22,6 +22,7 @@
 // will ignore these settings and use their own.
 #define SERIAL_RX_PIN 13
 #define SERIAL_TX_PIN 15
+
 // A different baud rate to communicate with the Meshtastic device can be specified here
 #define BAUD_RATE 9600
 
@@ -39,12 +40,17 @@ void connected_callback(mt_node_t *node, mt_nr_progress_t progress) {
 }
 
 // This callback function will be called whenever the radio receives a text message
-void text_message_callback(uint32_t from, const char* text) {
+void text_message_callback(uint32_t from, uint32_t to, const char* text) {
   // Do your own thing here. This example just prints the message to the serial console.
-  Serial.print("Received a text message from ");
+  Serial.print("Received a text message from: ");
   Serial.print(from);
-  Serial.print(": ");
+  Serial.print(" to: ");
+  Serial.print(to);
+  Serial.print(" message: ");
   Serial.println(text);
+  if (to == my_node_num){
+    Serial.println("This is a DM to me!");
+  }
 }
 
 void setup() {
@@ -80,7 +86,7 @@ void setup() {
   mt_request_node_report(connected_callback);
 
   // Register a callback function to be called whenever a text message is received
-  set_text_message_callback(text_message_callback);
+  set_directed_text_message_callback(text_message_callback);
 }
 
 void loop() {

--- a/examples/SendReceiveClient/SendReceiveClient.ino
+++ b/examples/SendReceiveClient/SendReceiveClient.ino
@@ -22,7 +22,6 @@
 // will ignore these settings and use their own.
 #define SERIAL_RX_PIN 13
 #define SERIAL_TX_PIN 15
-
 // A different baud rate to communicate with the Meshtastic device can be specified here
 #define BAUD_RATE 9600
 

--- a/src/Meshtastic.h
+++ b/src/Meshtastic.h
@@ -75,6 +75,9 @@ bool mt_request_node_report(void (*callback)(mt_node_t *, mt_nr_progress_t));
 // Set the callback function that gets called when the node receives a text message.
 void set_text_message_callback(void (*callback)(uint32_t from, const char * text));
 
+// Set the callback function that gets called when the node receives a text message.
+void set_adv_text_message_callback(void (*callback)(uint32_t from, uint32_t to, const char * text));
+
 // Send a text message with *text* as payload, to a destination node (optional), on a certain channel (optional).
 bool mt_send_text(const char * text, uint32_t dest = BROADCAST_ADDR, uint8_t channel_index = 0);
 

--- a/src/Meshtastic.h
+++ b/src/Meshtastic.h
@@ -76,7 +76,7 @@ bool mt_request_node_report(void (*callback)(mt_node_t *, mt_nr_progress_t));
 void set_text_message_callback(void (*callback)(uint32_t from, const char * text));
 
 // Set the callback function that gets called when the node receives a text message.
-void set_adv_text_message_callback(void (*callback)(uint32_t from, uint32_t to, const char * text));
+void set_directed_text_message_callback(void (*callback)(uint32_t from, uint32_t to, const char * text));
 
 // Send a text message with *text* as payload, to a destination node (optional), on a certain channel (optional).
 bool mt_send_text(const char * text, uint32_t dest = BROADCAST_ADDR, uint8_t channel_index = 0);

--- a/src/Meshtastic.h
+++ b/src/Meshtastic.h
@@ -75,7 +75,7 @@ bool mt_request_node_report(void (*callback)(mt_node_t *, mt_nr_progress_t));
 // Set the callback function that gets called when the node receives a text message.
 void set_text_message_callback(void (*callback)(uint32_t from, const char * text));
 
-// Set the callback function that gets called when the node receives a text message.
+// Set the callback function that gets called when the node receives a text message. Includes the 'to' parameter to catch DM's vs Broadcast.
 void set_directed_text_message_callback(void (*callback)(uint32_t from, uint32_t to, const char * text));
 
 // Send a text message with *text* as payload, to a destination node (optional), on a certain channel (optional).

--- a/src/Meshtastic.h
+++ b/src/Meshtastic.h
@@ -73,10 +73,7 @@ typedef enum {
 bool mt_request_node_report(void (*callback)(mt_node_t *, mt_nr_progress_t));
 
 // Set the callback function that gets called when the node receives a text message.
-void set_text_message_callback(void (*callback)(uint32_t from, const char * text));
-
-// Set the callback function that gets called when the node receives a text message. Includes the 'to' parameter to catch DM's vs Broadcast.
-void set_directed_text_message_callback(void (*callback)(uint32_t from, uint32_t to, const char * text));
+void set_text_message_callback(void (*callback)(uint32_t from, uint32_t to, const char * text));
 
 // Send a text message with *text* as payload, to a destination node (optional), on a certain channel (optional).
 bool mt_send_text(const char * text, uint32_t dest = BROADCAST_ADDR, uint8_t channel_index = 0);

--- a/src/mt_protocol.cpp
+++ b/src/mt_protocol.cpp
@@ -24,7 +24,7 @@ uint32_t my_node_num = 0;
 
 bool mt_debugging = false;
 void (*text_message_callback)(uint32_t from, const char* text) = NULL;
-void (*adv_text_message_callback)(uint32_t from, uint32_t to, const char* text) = NULL;
+void (*directed_text_message_callback)(uint32_t from, uint32_t to, const char* text) = NULL;
 void (*node_report_callback)(mt_node_t *, mt_nr_progress_t) = NULL;
 mt_node_t node;
 
@@ -121,8 +121,8 @@ void set_text_message_callback(void (*callback)(uint32_t from, const char* text)
   text_message_callback = callback;
 }
 
-void set_adv_text_message_callback(void (*callback)(uint32_t from, uint32_t to, const char* text)) {
-  adv_text_message_callback = callback;
+void set_directed_text_message_callback(void (*callback)(uint32_t from, uint32_t to, const char* text)) {
+  directed_text_message_callback = callback;
 }
 
 bool handle_my_info(meshtastic_MyNodeInfo *myNodeInfo) {
@@ -196,8 +196,8 @@ bool handle_mesh_packet(meshtastic_MeshPacket *meshPacket) {
     if (meshPacket->decoded.portnum == meshtastic_PortNum_TEXT_MESSAGE_APP) {
       if (text_message_callback != NULL)
         text_message_callback(meshPacket->from, (const char*)meshPacket->decoded.payload.bytes);
-      if (adv_text_message_callback != NULL)
-        adv_text_message_callback(meshPacket->from, meshPacket->to, (const char*)meshPacket->decoded.payload.bytes);
+      if (directed_text_message_callback != NULL)
+        directed_text_message_callback(meshPacket->from, meshPacket->to, (const char*)meshPacket->decoded.payload.bytes);
     } else {
       // TODO handle other portnums
       return false;

--- a/src/mt_protocol.cpp
+++ b/src/mt_protocol.cpp
@@ -23,8 +23,7 @@ uint32_t want_config_id = 0;
 uint32_t my_node_num = 0;
 
 bool mt_debugging = false;
-void (*text_message_callback)(uint32_t from, const char* text) = NULL;
-void (*directed_text_message_callback)(uint32_t from, uint32_t to, const char* text) = NULL;
+void (*text_message_callback)(uint32_t from, uint32_t to, const char* text) = NULL;
 void (*node_report_callback)(mt_node_t *, mt_nr_progress_t) = NULL;
 mt_node_t node;
 
@@ -117,12 +116,8 @@ bool mt_send_text(const char * text, uint32_t dest, uint8_t channel_index) {
   return _mt_send_toRadio(toRadio);
 }
 
-void set_text_message_callback(void (*callback)(uint32_t from, const char* text)) {
+void set_text_message_callback(void (*callback)(uint32_t from, uint32_t to, const char* text)) {
   text_message_callback = callback;
-}
-
-void set_directed_text_message_callback(void (*callback)(uint32_t from, uint32_t to, const char* text)) {
-  directed_text_message_callback = callback;
 }
 
 bool handle_my_info(meshtastic_MyNodeInfo *myNodeInfo) {
@@ -195,9 +190,7 @@ bool handle_mesh_packet(meshtastic_MeshPacket *meshPacket) {
   if (meshPacket->which_payload_variant == meshtastic_MeshPacket_decoded_tag) {
     if (meshPacket->decoded.portnum == meshtastic_PortNum_TEXT_MESSAGE_APP) {
       if (text_message_callback != NULL)
-        text_message_callback(meshPacket->from, (const char*)meshPacket->decoded.payload.bytes);
-      if (directed_text_message_callback != NULL)
-        directed_text_message_callback(meshPacket->from, meshPacket->to, (const char*)meshPacket->decoded.payload.bytes);
+        text_message_callback(meshPacket->from, meshPacket->to, (const char*)meshPacket->decoded.payload.bytes);
     } else {
       // TODO handle other portnums
       return false;

--- a/src/mt_protocol.cpp
+++ b/src/mt_protocol.cpp
@@ -24,6 +24,7 @@ uint32_t my_node_num = 0;
 
 bool mt_debugging = false;
 void (*text_message_callback)(uint32_t from, const char* text) = NULL;
+void (*adv_text_message_callback)(uint32_t from, uint32_t to, const char* text) = NULL;
 void (*node_report_callback)(mt_node_t *, mt_nr_progress_t) = NULL;
 mt_node_t node;
 
@@ -120,6 +121,10 @@ void set_text_message_callback(void (*callback)(uint32_t from, const char* text)
   text_message_callback = callback;
 }
 
+void set_adv_text_message_callback(void (*callback)(uint32_t from, uint32_t to, const char* text)) {
+  adv_text_message_callback = callback;
+}
+
 bool handle_my_info(meshtastic_MyNodeInfo *myNodeInfo) {
   my_node_num = myNodeInfo->my_node_num;
   return true;
@@ -191,6 +196,8 @@ bool handle_mesh_packet(meshtastic_MeshPacket *meshPacket) {
     if (meshPacket->decoded.portnum == meshtastic_PortNum_TEXT_MESSAGE_APP) {
       if (text_message_callback != NULL)
         text_message_callback(meshPacket->from, (const char*)meshPacket->decoded.payload.bytes);
+      if (adv_text_message_callback != NULL)
+        adv_text_message_callback(meshPacket->from, meshPacket->to, (const char*)meshPacket->decoded.payload.bytes);
     } else {
       // TODO handle other portnums
       return false;


### PR DESCRIPTION
This PR:
- Adds `set_directed_text_message_callback` modeled from `set_text_message_callback` with the addition of the `to` property.
- Modifies SendReceiveClient.ino to use the new function and call out a DM to the receiver.
