### PR TITLE
add channel to text_message_callback

### DIFF
--- a/examples/SendReceiveClient/SendReceiveClient.ino
+++ b/examples/SendReceiveClient/SendReceiveClient.ino
@@ -39,9 +39,11 @@ void connected_callback(mt_node_t *node, mt_nr_progress_t progress) {
 }
 
 // This callback function will be called whenever the radio receives a text message
-void text_message_callback(uint32_t from, uint32_t to, const char* text) {
+void text_message_callback(uint32_t from, uint32_t to,  uint8_t channel, const char* text) {
   // Do your own thing here. This example just prints the message to the serial console.
-  Serial.print("Received a text message from: ");
+  Serial.print("Received a text message on channel: ");
+  Serial.print(channel);
+  Serial.print(" from: ");
   Serial.print(from);
   Serial.print(" to: ");
   Serial.print(to);

--- a/src/Meshtastic.h
+++ b/src/Meshtastic.h
@@ -73,7 +73,7 @@ typedef enum {
 bool mt_request_node_report(void (*callback)(mt_node_t *, mt_nr_progress_t));
 
 // Set the callback function that gets called when the node receives a text message.
-void set_text_message_callback(void (*callback)(uint32_t from, uint32_t to, const char * text));
+void set_text_message_callback(void (*callback)(uint32_t from, uint32_t to, uint8_t channel, const char * text));
 
 // Send a text message with *text* as payload, to a destination node (optional), on a certain channel (optional).
 bool mt_send_text(const char * text, uint32_t dest = BROADCAST_ADDR, uint8_t channel_index = 0);

--- a/src/mt_protocol.cpp
+++ b/src/mt_protocol.cpp
@@ -23,7 +23,7 @@ uint32_t want_config_id = 0;
 uint32_t my_node_num = 0;
 
 bool mt_debugging = false;
-void (*text_message_callback)(uint32_t from, uint32_t to, const char* text) = NULL;
+void (*text_message_callback)(uint32_t from, uint32_t to,  uint8_t channel, const char* text) = NULL;
 void (*node_report_callback)(mt_node_t *, mt_nr_progress_t) = NULL;
 mt_node_t node;
 
@@ -116,7 +116,7 @@ bool mt_send_text(const char * text, uint32_t dest, uint8_t channel_index) {
   return _mt_send_toRadio(toRadio);
 }
 
-void set_text_message_callback(void (*callback)(uint32_t from, uint32_t to, const char* text)) {
+void set_text_message_callback(void (*callback)(uint32_t from, uint32_t to,  uint8_t channel, const char* text)) {
   text_message_callback = callback;
 }
 
@@ -190,7 +190,7 @@ bool handle_mesh_packet(meshtastic_MeshPacket *meshPacket) {
   if (meshPacket->which_payload_variant == meshtastic_MeshPacket_decoded_tag) {
     if (meshPacket->decoded.portnum == meshtastic_PortNum_TEXT_MESSAGE_APP) {
       if (text_message_callback != NULL)
-        text_message_callback(meshPacket->from, meshPacket->to, (const char*)meshPacket->decoded.payload.bytes);
+        text_message_callback(meshPacket->from, meshPacket->to, meshPacket->channel, (const char*)meshPacket->decoded.payload.bytes);
     } else {
       // TODO handle other portnums
       return false;


### PR DESCRIPTION
This PR adds `channel` to the text_message_callback and adds example usage to SendReceiveClient.ino.
