### PR TITLE
Add compatibility with SAMD21 properly

### DIFF
--- a/src/mt_internals.h
+++ b/src/mt_internals.h
@@ -1,11 +1,6 @@
 #ifndef MT_INTERNALS_H
 #define MT_INTERNALS_H
 
-// As per original code: to support Adafruit Feather M0 WiFi
-#ifdef ARDUINO_ARCH_SAMD
-#define MT_WIFI_SUPPORTED
-#endif
-
 #include "Meshtastic.h"
 
 extern bool mt_debugging;

--- a/src/mt_serial.cpp
+++ b/src/mt_serial.cpp
@@ -15,7 +15,7 @@ void mt_serial_init(int8_t rx_pin, int8_t tx_pin, uint32_t baud) {
 
 // Platform specific: init serial
 #if defined(ARDUINO_ARCH_SAMD)
-  // No call to begin(), as per original code
+  serial->begin(baud);
 #elif defined(ARDUINO_ARCH_ESP32)
   serial->begin(baud, SERIAL_8N1, rx_pin, tx_pin);
 #else


### PR DESCRIPTION
```cpp
#ifdef ARDUINO_ARCH_SAMD
#define MT_WIFI_SUPPORTED
#endif
```
Currently, WiFi support is enabled solely based on ARDUINO_ARCH_SAMD macro,
which is too broad and causes linking errors on non-WiFi SAMD boards.

Instead of automatic detection, this change requires users to explicitly
enable WiFi support through a configuration flag. This prevents unexpected
linking errors on SAMD boards that don't have WiFi capabilities (like
Arduino Zero or other M0-based boards without WiFi hardware).

The change affects:
- Removes automatic WiFi detection based on architecture
- Users must now define MT_WIFI_SUPPORTED explicitly
- Prevents linking errors on non-Feather M0 SAMD boards

#### Other Changes

 * Setup baud rate