### PR TITLE
update to library and example to create robust processing and callbacks for both decoded and encrypted and generic PortNum

### DIFF
--- a/examples/NodeInfoClient/NodeInfoClient.ino
+++ b/examples/NodeInfoClient/NodeInfoClient.ino
@@ -67,9 +67,6 @@ void setup() {
 #endif
   Serial.println(" mode");
 
-  // Set to true if you want debug messages
-  mt_set_debug(false);
-  
   randomSeed(micros());
 }
 

--- a/examples/NodeInfoClient/NodeInfoClient.ino
+++ b/examples/NodeInfoClient/NodeInfoClient.ino
@@ -16,6 +16,9 @@
 
 */
 
+// Uncomment the line below to enable debugging 
+// #define MT_DEBUGGING
+
 #include <Meshtastic.h>
 
 // Pins to use for WiFi; these defaults are for an Adafruit Feather M0 WiFi.

--- a/examples/SendReceiveClient/SendReceiveClient.ino
+++ b/examples/SendReceiveClient/SendReceiveClient.ino
@@ -9,6 +9,9 @@
     which prints the message to the serial console.
 */
 
+// Uncomment the line below to enable debugging 
+// #define MT_DEBUGGING
+
 #include <Meshtastic.h>
 
 // Pins to use for WiFi; these defaults are for an Adafruit Feather M0 WiFi.

--- a/examples/SendReceiveClient/SendReceiveClient.ino
+++ b/examples/SendReceiveClient/SendReceiveClient.ino
@@ -134,9 +134,6 @@ void setup() {
 #endif
   Serial.println(" mode");
 
-  // Set to true if you want debug messages
-  mt_set_debug(true);
-  
   randomSeed(micros());
 
   // Initial connection to the Meshtastic device

--- a/examples/SendReceiveClient/SendReceiveClient.ino
+++ b/examples/SendReceiveClient/SendReceiveClient.ino
@@ -20,8 +20,8 @@
 // Pins to use for SoftwareSerial. Boards that don't use SoftwareSerial, and
 // instead provide their own Serial1 connection through fixed pins
 // will ignore these settings and use their own.
-#define SERIAL_RX_PIN D5
-#define SERIAL_TX_PIN D4
+#define SERIAL_RX_PIN 13
+#define SERIAL_TX_PIN 15
 // A different baud rate to communicate with the Meshtastic device can be specified here
 #define BAUD_RATE 38400
 

--- a/examples/SendReceiveClient/SendReceiveClient.ino
+++ b/examples/SendReceiveClient/SendReceiveClient.ino
@@ -20,10 +20,10 @@
 // Pins to use for SoftwareSerial. Boards that don't use SoftwareSerial, and
 // instead provide their own Serial1 connection through fixed pins
 // will ignore these settings and use their own.
-#define SERIAL_RX_PIN 13
-#define SERIAL_TX_PIN 15
+#define SERIAL_RX_PIN D5
+#define SERIAL_TX_PIN D4
 // A different baud rate to communicate with the Meshtastic device can be specified here
-#define BAUD_RATE 9600
+#define BAUD_RATE 38400
 
 // Send a text message every this many seconds
 #define SEND_PERIOD 300
@@ -36,6 +36,58 @@ void connected_callback(mt_node_t *node, mt_nr_progress_t progress) {
   if (not_yet_connected) 
     Serial.println("Connected to Meshtastic device!");
   not_yet_connected = false;
+}
+
+
+const char* meshtastic_portnum_to_string(meshtastic_PortNum port) {
+  switch (port) {
+      case meshtastic_PortNum_UNKNOWN_APP: return "UNKNOWN_APP";
+      case meshtastic_PortNum_TEXT_MESSAGE_APP: return "TEXT_MESSAGE_APP";
+      case meshtastic_PortNum_REMOTE_HARDWARE_APP: return "REMOTE_HARDWARE_APP";
+      case meshtastic_PortNum_POSITION_APP: return "POSITION_APP";
+      case meshtastic_PortNum_NODEINFO_APP: return "NODEINFO_APP";
+      case meshtastic_PortNum_ROUTING_APP: return "ROUTING_APP";
+      case meshtastic_PortNum_ADMIN_APP: return "ADMIN_APP";
+      case meshtastic_PortNum_TEXT_MESSAGE_COMPRESSED_APP: return "TEXT_MESSAGE_COMPRESSED_APP";
+      case meshtastic_PortNum_WAYPOINT_APP: return "WAYPOINT_APP";
+      case meshtastic_PortNum_AUDIO_APP: return "AUDIO_APP";
+      case meshtastic_PortNum_DETECTION_SENSOR_APP: return "DETECTION_SENSOR_APP";
+      case meshtastic_PortNum_REPLY_APP: return "REPLY_APP";
+      case meshtastic_PortNum_IP_TUNNEL_APP: return "IP_TUNNEL_APP";
+      case meshtastic_PortNum_PAXCOUNTER_APP: return "PAXCOUNTER_APP";
+      case meshtastic_PortNum_SERIAL_APP: return "SERIAL_APP";
+      case meshtastic_PortNum_STORE_FORWARD_APP: return "STORE_FORWARD_APP";
+      case meshtastic_PortNum_RANGE_TEST_APP: return "RANGE_TEST_APP";
+      case meshtastic_PortNum_TELEMETRY_APP: return "TELEMETRY_APP";
+      case meshtastic_PortNum_ZPS_APP: return "ZPS_APP";
+      case meshtastic_PortNum_SIMULATOR_APP: return "SIMULATOR_APP";
+      case meshtastic_PortNum_TRACEROUTE_APP: return "TRACEROUTE_APP";
+      case meshtastic_PortNum_NEIGHBORINFO_APP: return "NEIGHBORINFO_APP";
+      case meshtastic_PortNum_ATAK_PLUGIN: return "ATAK_PLUGIN";
+      case meshtastic_PortNum_MAP_REPORT_APP: return "MAP_REPORT_APP";
+      case meshtastic_PortNum_POWERSTRESS_APP: return "POWERSTRESS_APP";
+      case meshtastic_PortNum_PRIVATE_APP: return "PRIVATE_APP";
+      case meshtastic_PortNum_ATAK_FORWARDER: return "ATAK_FORWARDER";
+      case meshtastic_PortNum_MAX: return "MAX";
+      default: return "UNKNOWN_PORTNUM";
+  }
+}
+
+void displayPubKey(meshtastic_MeshPacket_public_key_t pubKey, char *hex_str) {
+      for (int i = 0; i < 32; i++) {
+          sprintf(&hex_str[i * 2], "%02x", (unsigned char)pubKey.bytes[i]);
+      }
+  
+      hex_str[64] = '\0'; // Null terminator
+}
+
+
+void encrypted_callback(uint32_t from, uint32_t to,  uint8_t channel, meshtastic_MeshPacket_public_key_t pubKey, meshtastic_MeshPacket_encrypted_t *enc_payload) {
+  Serial.printf("Received an ENCRYPTED callback from: %x to: %x\r\n", from, to);
+}
+
+void portnum_callback(uint32_t from, uint32_t to,  uint8_t channel, meshtastic_PortNum portNum, meshtastic_Data_payload_t *payload) {
+  Serial.printf("Received a callback for PortNum %s\r\n", meshtastic_portnum_to_string(portNum));
 }
 
 // This callback function will be called whenever the radio receives a text message
@@ -59,8 +111,8 @@ void text_message_callback(uint32_t from, uint32_t to,  uint8_t channel, const c
 }
 
 void setup() {
-  // Try for up to five seconds to find a serial port; if not, the show must go on
-  Serial.begin(9600);
+  // Try for up to five seconds to find a serial port; if not, the show must gox on
+  Serial.begin(115200);
   while(true) {
     if (Serial) break;
     if (millis() > 5000) {
@@ -83,7 +135,7 @@ void setup() {
   Serial.println(" mode");
 
   // Set to true if you want debug messages
-  mt_set_debug(false);
+  mt_set_debug(true);
   
   randomSeed(micros());
 
@@ -92,6 +144,8 @@ void setup() {
 
   // Register a callback function to be called whenever a text message is received
   set_text_message_callback(text_message_callback);
+  set_portnum_callback(portnum_callback);
+  set_encrypted_callback(encrypted_callback);
 }
 
 void loop() {

--- a/src/Meshtastic.h
+++ b/src/Meshtastic.h
@@ -75,6 +75,12 @@ bool mt_request_node_report(void (*callback)(mt_node_t *, mt_nr_progress_t));
 // Set the callback function that gets called when the node receives a text message.
 void set_text_message_callback(void (*callback)(uint32_t from, uint32_t to, uint8_t channel, const char * text));
 
+// Set the callback function that gets called when the node receives any other portNum
+void set_portnum_callback(void (*callback)(uint32_t from, uint32_t to,  uint8_t channel, meshtastic_PortNum port, meshtastic_Data_payload_t *payload));
+
+// Set the callback function that gets called when the node receives an encrypted payload
+void set_encrypted_callback(void (*callback)(uint32_t from, uint32_t to,  uint8_t channel, meshtastic_MeshPacket_public_key_t pubKey, meshtastic_MeshPacket_encrypted_t *payload));
+
 // Send a text message with *text* as payload, to a destination node (optional), on a certain channel (optional).
 bool mt_send_text(const char * text, uint32_t dest = BROADCAST_ADDR, uint8_t channel_index = 0);
 

--- a/src/mt_internals.h
+++ b/src/mt_internals.h
@@ -5,7 +5,7 @@
 
 extern bool mt_debugging;
 void mt_debug_print(const char * s);
-#define d(s) mt_debug_print(s)
+void d(const char * fmt, ...);
 
 extern bool mt_wifi_mode;
 extern bool mt_serial_mode;

--- a/src/mt_internals.h
+++ b/src/mt_internals.h
@@ -3,7 +3,8 @@
 
 #include "Meshtastic.h"
 
-#undef MT_DEBUGGING 
+// Uncomment the line below to enable debugging 
+// #define MT_DEBUGGING
 #ifdef MT_DEBUGGING
 #define d(...) _d(__VA_ARGS__)
 #else

--- a/src/mt_internals.h
+++ b/src/mt_internals.h
@@ -3,9 +3,14 @@
 
 #include "Meshtastic.h"
 
-extern bool mt_debugging;
-void mt_debug_print(const char * s);
-void d(const char * fmt, ...);
+#undef MT_DEBUGGING 
+#ifdef MT_DEBUGGING
+#define d(...) _d(__VA_ARGS__)
+#else
+#define d(...) do {} while (0) 
+#endif
+
+void _d(const char * fmt, ...);
 
 extern bool mt_wifi_mode;
 extern bool mt_serial_mode;

--- a/src/mt_internals.h
+++ b/src/mt_internals.h
@@ -3,8 +3,6 @@
 
 #include "Meshtastic.h"
 
-// Uncomment the line below to enable debugging 
-// #define MT_DEBUGGING
 #ifdef MT_DEBUGGING
 #define d(...) _d(__VA_ARGS__)
 #else

--- a/src/mt_protocol.cpp
+++ b/src/mt_protocol.cpp
@@ -610,11 +610,12 @@ bool handle_mesh_packet(meshtastic_MeshPacket *meshPacket) {
           Serial.printf("Unknown portnum %d\r\n", meshPacket->decoded.portnum);
             return false;
     }
-  } else {
-      Serial.printf("encoded packet on PortNum %d\r\n", meshPacket->decoded.portnum);
-      if (encrypted_callback != NULL)
+  } else if  (meshPacket -> which_payload_variant == meshtastic_MeshPacket_encrypted_tag ) {
+      Serial.printf("encoded packet From: %x To: %x\r\n", meshPacket->from, meshPacket->to);
+      if (encrypted_callback != NULL) {
           encrypted_callback(meshPacket->from, meshPacket->to, meshPacket->channel, meshPacket->public_key, &meshPacket->encrypted);
-
+    	    return true;
+      }
     	return false;
   }
   return true;

--- a/src/mt_protocol.cpp
+++ b/src/mt_protocol.cpp
@@ -43,8 +43,15 @@ mt_node_t node;
 bool mt_wifi_mode = false;
 bool mt_serial_mode = false;
 
-void d(const char * s) {
-  if (mt_debugging) Serial.println(s);
+#define VA_BUFSIZE 512
+void d(const char * fmt, ...) {
+  static char vabuf[VA_BUFSIZE];
+  if (mt_debugging) {
+	  va_list ap;
+	  va_start(ap, fmt);
+	  vsnprintf(vabuf, sizeof(vabuf), fmt, ap);
+	  Serial.println(vabuf);
+  }
 }
 
 void mt_set_debug(bool on) {
@@ -154,349 +161,349 @@ void set_text_message_callback(void (*callback)(uint32_t from, uint32_t to,  uin
 }
 
 bool handle_id_tag(uint32_t id) {
-  Serial.printf("id_tag: ID: %d\r\n", id);
+  d("id_tag: ID: %d\r\n", id);
   return true;
 }
 
 bool handle_config_tag(meshtastic_Config *config) {
   switch (config->which_payload_variant) {
     case meshtastic_Config_device_tag:
-      Serial.printf("Config:device_tag:  role: %d\r\n", config->payload_variant.device.role);
-      Serial.printf("Config:device_tag:  serial enabled: %d\r\n", config->payload_variant.device.serial_enabled);
-      Serial.printf("Config:device_tag:  button gpio: %d\r\n", config->payload_variant.device.button_gpio);
-      Serial.printf("Config:device_tag:  buzzer gpio: %d\r\n", config->payload_variant.device.buzzer_gpio);
-      Serial.printf("Config:device_tag:  rebroadcast mode: %d\r\n", config->payload_variant.device.rebroadcast_mode);
-      Serial.printf("Config:device_tag:  node_info_broadcast_secs: %d\r\n", config->payload_variant.device.node_info_broadcast_secs);
-      Serial.printf("Config:device_tag:  double-tap-as-button-press: %d\r\n", config->payload_variant.device.double_tap_as_button_press);
-      Serial.printf("Config:device_tag:  is_managed: %d\r\n", config->payload_variant.device.is_managed);
-      Serial.printf("Config:device_tag:  disable_triple_click: %d\r\n", config->payload_variant.device.disable_triple_click);
-      Serial.printf("Config:device_tag:  tz_def: %s\r\n", config->payload_variant.device.tzdef);
-      Serial.printf("Config:device_tag:  led_heartbeat_disabled: %d\r\n", config->payload_variant.device.led_heartbeat_disabled);
+      d("Config:device_tag:  role: %d\r\n", config->payload_variant.device.role);
+      d("Config:device_tag:  serial enabled: %d\r\n", config->payload_variant.device.serial_enabled);
+      d("Config:device_tag:  button gpio: %d\r\n", config->payload_variant.device.button_gpio);
+      d("Config:device_tag:  buzzer gpio: %d\r\n", config->payload_variant.device.buzzer_gpio);
+      d("Config:device_tag:  rebroadcast mode: %d\r\n", config->payload_variant.device.rebroadcast_mode);
+      d("Config:device_tag:  node_info_broadcast_secs: %d\r\n", config->payload_variant.device.node_info_broadcast_secs);
+      d("Config:device_tag:  double-tap-as-button-press: %d\r\n", config->payload_variant.device.double_tap_as_button_press);
+      d("Config:device_tag:  is_managed: %d\r\n", config->payload_variant.device.is_managed);
+      d("Config:device_tag:  disable_triple_click: %d\r\n", config->payload_variant.device.disable_triple_click);
+      d("Config:device_tag:  tz_def: %s\r\n", config->payload_variant.device.tzdef);
+      d("Config:device_tag:  led_heartbeat_disabled: %d\r\n", config->payload_variant.device.led_heartbeat_disabled);
       break;
 
     case meshtastic_Config_position_tag:
-      Serial.printf("Config:position_tag:  position_broadcast_secs: %d\r\n", config->payload_variant.position.position_broadcast_secs);
-      Serial.printf("Config:position_tag:  position_broadcast_smart_enabled: %d\r\n", config->payload_variant.position.position_broadcast_smart_enabled);
-      Serial.printf("Config:position_tag:  fixed_position: %d\r\n", config->payload_variant.position.fixed_position);
-      Serial.printf("Config:position_tag:  gps_enabled: %d\r\n", config->payload_variant.position.gps_enabled);
-      Serial.printf("Config:position_tag:  gps_update_interval: %d\r\n", config->payload_variant.position.gps_update_interval);
-      Serial.printf("Config:position_tag:  gps_attempt_time: %d\r\n", config->payload_variant.position.gps_attempt_time);
-      Serial.printf("Config:position_tag:  position_flags: %d\r\n", config->payload_variant.position.position_flags);
-      Serial.printf("Config:position_tag:  rx_gpio: %d\r\n", config->payload_variant.position.rx_gpio);
-      Serial.printf("Config:position_tag:  tx_gpio: %d\r\n", config->payload_variant.position.tx_gpio);
-      Serial.printf("Config:position_tag:  broadcast_smart_min_distance: %d\r\n", config->payload_variant.position.broadcast_smart_minimum_distance);
-      Serial.printf("Config:position_tag:  broadcast_smart_min_interval_secs: %d\r\n", config->payload_variant.position.broadcast_smart_minimum_interval_secs);
-      Serial.printf("Config:position_tag:  gps_en_gpio: %d\r\n", config->payload_variant.position.gps_en_gpio);
-      Serial.printf("Config:position_tag:  gps_mode %d\r\n", config->payload_variant.position.gps_mode);
+      d("Config:position_tag:  position_broadcast_secs: %d\r\n", config->payload_variant.position.position_broadcast_secs);
+      d("Config:position_tag:  position_broadcast_smart_enabled: %d\r\n", config->payload_variant.position.position_broadcast_smart_enabled);
+      d("Config:position_tag:  fixed_position: %d\r\n", config->payload_variant.position.fixed_position);
+      d("Config:position_tag:  gps_enabled: %d\r\n", config->payload_variant.position.gps_enabled);
+      d("Config:position_tag:  gps_update_interval: %d\r\n", config->payload_variant.position.gps_update_interval);
+      d("Config:position_tag:  gps_attempt_time: %d\r\n", config->payload_variant.position.gps_attempt_time);
+      d("Config:position_tag:  position_flags: %d\r\n", config->payload_variant.position.position_flags);
+      d("Config:position_tag:  rx_gpio: %d\r\n", config->payload_variant.position.rx_gpio);
+      d("Config:position_tag:  tx_gpio: %d\r\n", config->payload_variant.position.tx_gpio);
+      d("Config:position_tag:  broadcast_smart_min_distance: %d\r\n", config->payload_variant.position.broadcast_smart_minimum_distance);
+      d("Config:position_tag:  broadcast_smart_min_interval_secs: %d\r\n", config->payload_variant.position.broadcast_smart_minimum_interval_secs);
+      d("Config:position_tag:  gps_en_gpio: %d\r\n", config->payload_variant.position.gps_en_gpio);
+      d("Config:position_tag:  gps_mode %d\r\n", config->payload_variant.position.gps_mode);
       break;
 
     case meshtastic_Config_power_tag: 
-      Serial.printf("Config:power_tag:  is_power_saving %d\r\n", config->payload_variant.power.is_power_saving);
-      Serial.printf("Config:power_tag:  on_battery_shutdown_after_secs %d\r\n", config->payload_variant.power.on_battery_shutdown_after_secs);
-      Serial.printf("Config:power_tag:  adv_multiplier_override %f\r\n", config->payload_variant.power.adc_multiplier_override);
-      Serial.printf("Config:power_tag:  wait_bluetooth_secs %d\r\n", config->payload_variant.power.wait_bluetooth_secs);
-      Serial.printf("Config:power_tag:  sds_secs %d\r\n", config->payload_variant.power.sds_secs);
-      Serial.printf("Config:power_tag:  ls_secs %d\r\n", config->payload_variant.power.ls_secs);
-      Serial.printf("Config:power_tag:  min_wake_secs %d\r\n", config->payload_variant.power.min_wake_secs);
-      Serial.printf("Config:power_tag:  device_battery_ina_aaddr %d\r\n", config->payload_variant.power.device_battery_ina_address);
-      Serial.printf("Config:power_tag:  powermon_enables %d\r\n", config->payload_variant.power.powermon_enables);
+      d("Config:power_tag:  is_power_saving %d\r\n", config->payload_variant.power.is_power_saving);
+      d("Config:power_tag:  on_battery_shutdown_after_secs %d\r\n", config->payload_variant.power.on_battery_shutdown_after_secs);
+      d("Config:power_tag:  adv_multiplier_override %f\r\n", config->payload_variant.power.adc_multiplier_override);
+      d("Config:power_tag:  wait_bluetooth_secs %d\r\n", config->payload_variant.power.wait_bluetooth_secs);
+      d("Config:power_tag:  sds_secs %d\r\n", config->payload_variant.power.sds_secs);
+      d("Config:power_tag:  ls_secs %d\r\n", config->payload_variant.power.ls_secs);
+      d("Config:power_tag:  min_wake_secs %d\r\n", config->payload_variant.power.min_wake_secs);
+      d("Config:power_tag:  device_battery_ina_aaddr %d\r\n", config->payload_variant.power.device_battery_ina_address);
+      d("Config:power_tag:  powermon_enables %d\r\n", config->payload_variant.power.powermon_enables);
       break;
 
     case meshtastic_Config_network_tag:
-      Serial.printf("Config:network_tag:wifi_enabled: %d  \r\n", config->payload_variant.network.wifi_enabled);
-      Serial.printf("Config:network_tag:wifi_ssid: %s  \r\n", config->payload_variant.network.wifi_ssid);
-      Serial.printf("Config:network_tag:wifi_psk: %s  \r\n", config->payload_variant.network.wifi_psk);
-      Serial.printf("Config:network_tag:ntp_server: %s  \r\n", config->payload_variant.network.ntp_server);
-      Serial.printf("Config:network_tag:eth_enabled: %d  \r\n", config->payload_variant.network.eth_enabled);
-      Serial.printf("Config:network_tag:addr_mode: %d  \r\n", config->payload_variant.network.address_mode);
-      Serial.printf("Config:network_tag:has_ipv4_config: %d  \r\n", config->payload_variant.network.has_ipv4_config);
-      Serial.printf("Config:network_tag:ipv4_config: %d  \r\n", config->payload_variant.network.ipv4_config);
-      Serial.printf("Config:network_tag:rsyslog_server: %s  \r\n", config->payload_variant.network.rsyslog_server);
+      d("Config:network_tag:wifi_enabled: %d  \r\n", config->payload_variant.network.wifi_enabled);
+      d("Config:network_tag:wifi_ssid: %s  \r\n", config->payload_variant.network.wifi_ssid);
+      d("Config:network_tag:wifi_psk: %s  \r\n", config->payload_variant.network.wifi_psk);
+      d("Config:network_tag:ntp_server: %s  \r\n", config->payload_variant.network.ntp_server);
+      d("Config:network_tag:eth_enabled: %d  \r\n", config->payload_variant.network.eth_enabled);
+      d("Config:network_tag:addr_mode: %d  \r\n", config->payload_variant.network.address_mode);
+      d("Config:network_tag:has_ipv4_config: %d  \r\n", config->payload_variant.network.has_ipv4_config);
+      d("Config:network_tag:ipv4_config: %d  \r\n", config->payload_variant.network.ipv4_config);
+      d("Config:network_tag:rsyslog_server: %s  \r\n", config->payload_variant.network.rsyslog_server);
       break;
 
     case meshtastic_Config_display_tag: 
-      Serial.printf("Config:display_tag:screen_on_seconds: %d  \r\n", config->payload_variant.display.screen_on_secs);
-      Serial.printf("Config:display_tag:gps_format: %d  \r\n", config->payload_variant.display.gps_format);
-      Serial.printf("Config:display_tag:auto_screen_carousel_secs: %d  \r\n", config->payload_variant.display.auto_screen_carousel_secs);
-      Serial.printf("Config:display_tag:compass_north_top: %d  \r\n", config->payload_variant.display.compass_north_top);
-      Serial.printf("Config:display_tag:flip_screen: %d  \r\n", config->payload_variant.display.flip_screen);
-      Serial.printf("Config:display_tag:units: %d  \r\n", config->payload_variant.display.units);
-      Serial.printf("Config:display_tag:oled: %d  \r\n", config->payload_variant.display.oled);
-      Serial.printf("Config:display_tag:displayMode: %d  \r\n", config->payload_variant.display.displaymode);
-      Serial.printf("Config:display_tag:heading_bold: %d  \r\n", config->payload_variant.display.heading_bold);
-      Serial.printf("Config:display_tag:wake_on_tap_or_motion: %d  \r\n", config->payload_variant.display.wake_on_tap_or_motion);
-      Serial.printf("Config:display_tag:compass_orientation: %d  \r\n", config->payload_variant.display.compass_orientation);
+      d("Config:display_tag:screen_on_seconds: %d  \r\n", config->payload_variant.display.screen_on_secs);
+      d("Config:display_tag:gps_format: %d  \r\n", config->payload_variant.display.gps_format);
+      d("Config:display_tag:auto_screen_carousel_secs: %d  \r\n", config->payload_variant.display.auto_screen_carousel_secs);
+      d("Config:display_tag:compass_north_top: %d  \r\n", config->payload_variant.display.compass_north_top);
+      d("Config:display_tag:flip_screen: %d  \r\n", config->payload_variant.display.flip_screen);
+      d("Config:display_tag:units: %d  \r\n", config->payload_variant.display.units);
+      d("Config:display_tag:oled: %d  \r\n", config->payload_variant.display.oled);
+      d("Config:display_tag:displayMode: %d  \r\n", config->payload_variant.display.displaymode);
+      d("Config:display_tag:heading_bold: %d  \r\n", config->payload_variant.display.heading_bold);
+      d("Config:display_tag:wake_on_tap_or_motion: %d  \r\n", config->payload_variant.display.wake_on_tap_or_motion);
+      d("Config:display_tag:compass_orientation: %d  \r\n", config->payload_variant.display.compass_orientation);
       break;
 
     case meshtastic_Config_lora_tag:
-      Serial.printf("Config:lora_tag:use_preset: %d  \r\n", config->payload_variant.lora.use_preset);
-      Serial.printf("Config:lora_tag:modem_preset: %d  \r\n", config->payload_variant.lora.modem_preset);
-      Serial.printf("Config:lora_tag:bandwidth: %d  \r\n", config->payload_variant.lora.bandwidth);
-      Serial.printf("Config:lora_tag:spread_factor: %d  \r\n", config->payload_variant.lora.spread_factor);
-      Serial.printf("Config:lora_tag:coding_rate: %d  \r\n", config->payload_variant.lora.coding_rate);
-      Serial.printf("Config:lora_tag:frequency_offset: %d  \r\n", config->payload_variant.lora.frequency_offset);
-      Serial.printf("Config:lora_tag:region: %d  \r\n", config->payload_variant.lora.region);
-      Serial.printf("Config:lora_tag:hot_limit: %d  \r\n", config->payload_variant.lora.hop_limit);
-      Serial.printf("Config:lora_tag:tx_enabled: %d  \r\n", config->payload_variant.lora.tx_enabled);
-      Serial.printf("Config:lora_tag:tx_power: %d  \r\n", config->payload_variant.lora.tx_power);
-      Serial.printf("Config:lora_tag:channel_num: %d  \r\n", config->payload_variant.lora.channel_num);
-      Serial.printf("Config:lora_tag:override_duty_cycle: %d  \r\n", config->payload_variant.lora.override_duty_cycle);
-      Serial.printf("Config:lora_tag:sx126x_rx_boosted_gain: %d  \r\n", config->payload_variant.lora.sx126x_rx_boosted_gain);
-      Serial.printf("Config:lora_tag:override_frequency: %d  \r\n", config->payload_variant.lora.override_frequency);
-      Serial.printf("Config:lora_tag:pa_fan_disabled: %d  \r\n", config->payload_variant.lora.pa_fan_disabled);
-      Serial.printf("Config:lora_tag:ignore_incoming_count: %d  \r\n", config->payload_variant.lora.ignore_incoming_count);
-      Serial.printf("Config:lora_tag:ignore_mqtt: %d  \r\n", config->payload_variant.lora.ignore_mqtt);
-      Serial.printf("Config:lora_tag:config_okay_to_mqtt: %d  \r\n", config->payload_variant.lora.config_ok_to_mqtt);
+      d("Config:lora_tag:use_preset: %d  \r\n", config->payload_variant.lora.use_preset);
+      d("Config:lora_tag:modem_preset: %d  \r\n", config->payload_variant.lora.modem_preset);
+      d("Config:lora_tag:bandwidth: %d  \r\n", config->payload_variant.lora.bandwidth);
+      d("Config:lora_tag:spread_factor: %d  \r\n", config->payload_variant.lora.spread_factor);
+      d("Config:lora_tag:coding_rate: %d  \r\n", config->payload_variant.lora.coding_rate);
+      d("Config:lora_tag:frequency_offset: %d  \r\n", config->payload_variant.lora.frequency_offset);
+      d("Config:lora_tag:region: %d  \r\n", config->payload_variant.lora.region);
+      d("Config:lora_tag:hot_limit: %d  \r\n", config->payload_variant.lora.hop_limit);
+      d("Config:lora_tag:tx_enabled: %d  \r\n", config->payload_variant.lora.tx_enabled);
+      d("Config:lora_tag:tx_power: %d  \r\n", config->payload_variant.lora.tx_power);
+      d("Config:lora_tag:channel_num: %d  \r\n", config->payload_variant.lora.channel_num);
+      d("Config:lora_tag:override_duty_cycle: %d  \r\n", config->payload_variant.lora.override_duty_cycle);
+      d("Config:lora_tag:sx126x_rx_boosted_gain: %d  \r\n", config->payload_variant.lora.sx126x_rx_boosted_gain);
+      d("Config:lora_tag:override_frequency: %d  \r\n", config->payload_variant.lora.override_frequency);
+      d("Config:lora_tag:pa_fan_disabled: %d  \r\n", config->payload_variant.lora.pa_fan_disabled);
+      d("Config:lora_tag:ignore_incoming_count: %d  \r\n", config->payload_variant.lora.ignore_incoming_count);
+      d("Config:lora_tag:ignore_mqtt: %d  \r\n", config->payload_variant.lora.ignore_mqtt);
+      d("Config:lora_tag:config_okay_to_mqtt: %d  \r\n", config->payload_variant.lora.config_ok_to_mqtt);
       break;
 
     case meshtastic_Config_bluetooth_tag: 
-      Serial.printf("Config:bluetooth_tag:enabled: %d  \r\n", config->payload_variant.bluetooth.enabled);
-      Serial.printf("Config:bluetooth_tag:fixed_pin: %d  \r\n", config->payload_variant.bluetooth.fixed_pin);
-      Serial.printf("Config:bluetooth_tag:mode: %d  \r\n", config->payload_variant.bluetooth.mode);
+      d("Config:bluetooth_tag:enabled: %d  \r\n", config->payload_variant.bluetooth.enabled);
+      d("Config:bluetooth_tag:fixed_pin: %d  \r\n", config->payload_variant.bluetooth.fixed_pin);
+      d("Config:bluetooth_tag:mode: %d  \r\n", config->payload_variant.bluetooth.mode);
       break;
 
     case meshtastic_Config_security_tag: 
-      Serial.printf("Config:security_tag:is_managed: %d \r\n", config->payload_variant.security.is_managed);
-      Serial.printf("Config:security_tag:public_key: %x \r\n", config->payload_variant.security.public_key);
-      Serial.printf("Config:security_tag:private_key: %x \r\n", config->payload_variant.security.private_key);
-      Serial.printf("Config:security_tag:admin_key_count: %x \r\n", config->payload_variant.security.admin_key_count);
-      Serial.printf("Config:security_tag:serial_enabled: %x \r\n", config->payload_variant.security.serial_enabled);
-      Serial.printf("Config:security_tag:debug_log_api_enabled: %x \r\n", config->payload_variant.security.debug_log_api_enabled);
-      Serial.printf("Config:security_tag:admin_channel_enabled: %x \r\n", config->payload_variant.security.admin_channel_enabled);
+      d("Config:security_tag:is_managed: %d \r\n", config->payload_variant.security.is_managed);
+      d("Config:security_tag:public_key: %x \r\n", config->payload_variant.security.public_key);
+      d("Config:security_tag:private_key: %x \r\n", config->payload_variant.security.private_key);
+      d("Config:security_tag:admin_key_count: %x \r\n", config->payload_variant.security.admin_key_count);
+      d("Config:security_tag:serial_enabled: %x \r\n", config->payload_variant.security.serial_enabled);
+      d("Config:security_tag:debug_log_api_enabled: %x \r\n", config->payload_variant.security.debug_log_api_enabled);
+      d("Config:security_tag:admin_channel_enabled: %x \r\n", config->payload_variant.security.admin_channel_enabled);
       break;
 
     case meshtastic_Config_sessionkey_tag: 
-      Serial.printf("Config:sessionkey_tag:dummy_field: %x \r\n", config->payload_variant.sessionkey.dummy_field);
+      d("Config:sessionkey_tag:dummy_field: %x \r\n", config->payload_variant.sessionkey.dummy_field);
       break;
 
     case meshtastic_Config_device_ui_tag:
-      Serial.printf("Config.device_ui:alert_enabled: %d\r\n", config->payload_variant.device_ui.alert_enabled);
-      Serial.printf("Config.device_ui:banner_enabled: %d\r\n", config->payload_variant.device_ui.banner_enabled);
-      Serial.printf("Config.device_ui:has_node_filter: %d\r\n", config->payload_variant.device_ui.has_node_filter);
-      Serial.printf("Config.device_ui:has_node_highlight: %d\r\n", config->payload_variant.device_ui.has_node_highlight);
-      Serial.printf("Config.device_ui:language: %d\r\n", config->payload_variant.device_ui.language);
-      Serial.printf("Config.device_ui:node_filter: %d\r\n", config->payload_variant.device_ui.node_filter);
-      Serial.printf("Config.device_ui:node_highlight: %d\r\n", config->payload_variant.device_ui.node_highlight);
-      Serial.printf("Config.device_ui:pin_code: %d\r\n", config->payload_variant.device_ui.pin_code);
-      Serial.printf("Config.device_ui:ring_tone_id: %d\r\n", config->payload_variant.device_ui.ring_tone_id);
-      Serial.printf("Config.device_ui:screen_brightness: %d\r\n", config->payload_variant.device_ui.screen_brightness);
-      Serial.printf("Config.device_ui:screen_lock: %d\r\n", config->payload_variant.device_ui.screen_lock);
-      Serial.printf("Config.device_ui:screen_timeout: %d\r\n", config->payload_variant.device_ui.screen_timeout);
+      d("Config.device_ui:alert_enabled: %d\r\n", config->payload_variant.device_ui.alert_enabled);
+      d("Config.device_ui:banner_enabled: %d\r\n", config->payload_variant.device_ui.banner_enabled);
+      d("Config.device_ui:has_node_filter: %d\r\n", config->payload_variant.device_ui.has_node_filter);
+      d("Config.device_ui:has_node_highlight: %d\r\n", config->payload_variant.device_ui.has_node_highlight);
+      d("Config.device_ui:language: %d\r\n", config->payload_variant.device_ui.language);
+      d("Config.device_ui:node_filter: %d\r\n", config->payload_variant.device_ui.node_filter);
+      d("Config.device_ui:node_highlight: %d\r\n", config->payload_variant.device_ui.node_highlight);
+      d("Config.device_ui:pin_code: %d\r\n", config->payload_variant.device_ui.pin_code);
+      d("Config.device_ui:ring_tone_id: %d\r\n", config->payload_variant.device_ui.ring_tone_id);
+      d("Config.device_ui:screen_brightness: %d\r\n", config->payload_variant.device_ui.screen_brightness);
+      d("Config.device_ui:screen_lock: %d\r\n", config->payload_variant.device_ui.screen_lock);
+      d("Config.device_ui:screen_timeout: %d\r\n", config->payload_variant.device_ui.screen_timeout);
       break;
 
     default:
-      Serial.printf("Unknown Config_Tag payload variant: %d\r\n", config->which_payload_variant);
+      d("Unknown Config_Tag payload variant: %d\r\n", config->which_payload_variant);
   }
   return true;
 }
 
 bool handle_channel_tag(meshtastic_Channel *channel) {
-  Serial.printf("ChannelTag:index: %d\r\n", channel->index);
-  Serial.printf("ChannelTag:has_settings: %d\r\n", channel->has_settings);
-  Serial.printf("ChannelTag:role: %d\r\n", channel->role);
+  d("ChannelTag:index: %d\r\n", channel->index);
+  d("ChannelTag:has_settings: %d\r\n", channel->has_settings);
+  d("ChannelTag:role: %d\r\n", channel->role);
   return true;
 }
 
 bool handle_FromRadio_log_record_tag(meshtastic_LogRecord *record) {
-  Serial.printf("FromRadio_log_record:message: %s\r\n", record->message);
-  Serial.printf("FromRadio_log_record:time: %d\r\n", record->time);
-  Serial.printf("FromRadio_log_record:source: %s\r\n", record->source);
-  Serial.printf("FromRadio_log_record:level: %s\r\n", record->level);
+  d("FromRadio_log_record:message: %s\r\n", record->message);
+  d("FromRadio_log_record:time: %d\r\n", record->time);
+  d("FromRadio_log_record:source: %s\r\n", record->source);
+  d("FromRadio_log_record:level: %s\r\n", record->level);
   return true;
 }
 
 bool handle_moduleConfig_tag(meshtastic_ModuleConfig *module){ 
   switch (module->which_payload_variant) {
       case meshtastic_ModuleConfig_mqtt_tag:
-      Serial.printf("ModuleConfig:mqtt:enabled: %d\r\n", module->payload_variant.mqtt.enabled);
-      Serial.printf("ModuleConfig:mqtt:address: %s\r\n", module->payload_variant.mqtt.address);
-      Serial.printf("ModuleConfig:mqtt:username: %s\r\n", module->payload_variant.mqtt.username);
-      Serial.printf("ModuleConfig:mqtt:password: %s\r\n", module->payload_variant.mqtt.password);
-      Serial.printf("ModuleConfig:mqtt:encryption_enabled: %d\r\n", module->payload_variant.mqtt.encryption_enabled);
-      Serial.printf("ModuleConfig:mqtt:json_enabled: %d\r\n", module->payload_variant.mqtt.json_enabled);
-      Serial.printf("ModuleConfig:mqtt:root: %s\r\n", module->payload_variant.mqtt.root);
-      Serial.printf("ModuleConfig:mqtt:proxy_to_client_enabled: %d\r\n", module->payload_variant.mqtt.proxy_to_client_enabled);
-      Serial.printf("ModuleConfig:mqtt:map_reporting_enabled %d\r\n", module->payload_variant.mqtt.map_report_settings);
-      Serial.printf("ModuleConfig:mqtt:has_map_report_settings %d\r\n", module->payload_variant.mqtt.has_map_report_settings);
+      d("ModuleConfig:mqtt:enabled: %d\r\n", module->payload_variant.mqtt.enabled);
+      d("ModuleConfig:mqtt:address: %s\r\n", module->payload_variant.mqtt.address);
+      d("ModuleConfig:mqtt:username: %s\r\n", module->payload_variant.mqtt.username);
+      d("ModuleConfig:mqtt:password: %s\r\n", module->payload_variant.mqtt.password);
+      d("ModuleConfig:mqtt:encryption_enabled: %d\r\n", module->payload_variant.mqtt.encryption_enabled);
+      d("ModuleConfig:mqtt:json_enabled: %d\r\n", module->payload_variant.mqtt.json_enabled);
+      d("ModuleConfig:mqtt:root: %s\r\n", module->payload_variant.mqtt.root);
+      d("ModuleConfig:mqtt:proxy_to_client_enabled: %d\r\n", module->payload_variant.mqtt.proxy_to_client_enabled);
+      d("ModuleConfig:mqtt:map_reporting_enabled %d\r\n", module->payload_variant.mqtt.map_report_settings);
+      d("ModuleConfig:mqtt:has_map_report_settings %d\r\n", module->payload_variant.mqtt.has_map_report_settings);
       break;
 
       case meshtastic_ModuleConfig_serial_tag:
-        Serial.printf("ModuleConfig:serial:enabled: %d\r\n", module->payload_variant.serial.enabled);
-        Serial.printf("ModuleConfig:serial:echo: %d\r\n", module->payload_variant.serial.echo);
-        Serial.printf("ModuleConfig:serial:rxd-gpio-pin: %d\r\n", module->payload_variant.serial.rxd);
-        Serial.printf("ModuleConfig:serial:txd-gpio-pin: %d\r\n", module->payload_variant.serial.txd);
-        Serial.printf("ModuleConfig:serial:baud: %d\r\n", module->payload_variant.serial.baud);
-        Serial.printf("ModuleConfig:serial:timeout: %d\r\n", module->payload_variant.serial.timeout);
-        Serial.printf("ModuleConfig:serial:mode: %d\r\n", module->payload_variant.serial.mode);
-        Serial.printf("ModuleConfig:serial:override_console_serial_port: %d\r\n", module->payload_variant.serial.override_console_serial_port);
+        d("ModuleConfig:serial:enabled: %d\r\n", module->payload_variant.serial.enabled);
+        d("ModuleConfig:serial:echo: %d\r\n", module->payload_variant.serial.echo);
+        d("ModuleConfig:serial:rxd-gpio-pin: %d\r\n", module->payload_variant.serial.rxd);
+        d("ModuleConfig:serial:txd-gpio-pin: %d\r\n", module->payload_variant.serial.txd);
+        d("ModuleConfig:serial:baud: %d\r\n", module->payload_variant.serial.baud);
+        d("ModuleConfig:serial:timeout: %d\r\n", module->payload_variant.serial.timeout);
+        d("ModuleConfig:serial:mode: %d\r\n", module->payload_variant.serial.mode);
+        d("ModuleConfig:serial:override_console_serial_port: %d\r\n", module->payload_variant.serial.override_console_serial_port);
       break;
 
       case meshtastic_ModuleConfig_external_notification_tag:
-        Serial.printf("ModuleConfig:external_notification:enabled: %d\r\n", module->payload_variant.external_notification.enabled);
-        Serial.printf("ModuleConfig:external_notification:output_ms: %d\r\n", module->payload_variant.external_notification.output_ms);
-        Serial.printf("ModuleConfig:external_notification:output: %d\r\n", module->payload_variant.external_notification.output);
-        Serial.printf("ModuleConfig:external_notification:active: %d\r\n", module->payload_variant.external_notification.active);
-        Serial.printf("ModuleConfig:external_notification:alert_message: %d\r\n", module->payload_variant.external_notification.alert_message);
-        Serial.printf("ModuleConfig:external_notification:alert_bell: %d\r\n", module->payload_variant.external_notification.alert_bell);
-        Serial.printf("ModuleConfig:external_notification:use_pwm: %d\r\n", module->payload_variant.external_notification.use_pwm);
-        Serial.printf("ModuleConfig:external_notification:output_vibra: %d\r\n", module->payload_variant.external_notification.output_vibra);
-        Serial.printf("ModuleConfig:external_notification:output_buzzer: %d\r\n", module->payload_variant.external_notification.output_buzzer);
-        Serial.printf("ModuleConfig:external_notification:alert_message_vibra: %d\r\n", module->payload_variant.external_notification.alert_message_vibra);
-        Serial.printf("ModuleConfig:external_notification:alert_message_buzzer: %d\r\n", module->payload_variant.external_notification.alert_message_buzzer);
-        Serial.printf("ModuleConfig:external_notification:alert_bell_vibra: %d\r\n", module->payload_variant.external_notification.alert_bell_vibra);
-        Serial.printf("ModuleConfig:external_notification:alert_bell_buzzer: %d\r\n", module->payload_variant.external_notification.alert_bell_buzzer);
-        Serial.printf("ModuleConfig:external_notification:nag_timeout: %d\r\n", module->payload_variant.external_notification.nag_timeout);
-        Serial.printf("ModuleConfig:external_notification:use_i2s_as_buzzer: %d\r\n", module->payload_variant.external_notification.use_i2s_as_buzzer);
+        d("ModuleConfig:external_notification:enabled: %d\r\n", module->payload_variant.external_notification.enabled);
+        d("ModuleConfig:external_notification:output_ms: %d\r\n", module->payload_variant.external_notification.output_ms);
+        d("ModuleConfig:external_notification:output: %d\r\n", module->payload_variant.external_notification.output);
+        d("ModuleConfig:external_notification:active: %d\r\n", module->payload_variant.external_notification.active);
+        d("ModuleConfig:external_notification:alert_message: %d\r\n", module->payload_variant.external_notification.alert_message);
+        d("ModuleConfig:external_notification:alert_bell: %d\r\n", module->payload_variant.external_notification.alert_bell);
+        d("ModuleConfig:external_notification:use_pwm: %d\r\n", module->payload_variant.external_notification.use_pwm);
+        d("ModuleConfig:external_notification:output_vibra: %d\r\n", module->payload_variant.external_notification.output_vibra);
+        d("ModuleConfig:external_notification:output_buzzer: %d\r\n", module->payload_variant.external_notification.output_buzzer);
+        d("ModuleConfig:external_notification:alert_message_vibra: %d\r\n", module->payload_variant.external_notification.alert_message_vibra);
+        d("ModuleConfig:external_notification:alert_message_buzzer: %d\r\n", module->payload_variant.external_notification.alert_message_buzzer);
+        d("ModuleConfig:external_notification:alert_bell_vibra: %d\r\n", module->payload_variant.external_notification.alert_bell_vibra);
+        d("ModuleConfig:external_notification:alert_bell_buzzer: %d\r\n", module->payload_variant.external_notification.alert_bell_buzzer);
+        d("ModuleConfig:external_notification:nag_timeout: %d\r\n", module->payload_variant.external_notification.nag_timeout);
+        d("ModuleConfig:external_notification:use_i2s_as_buzzer: %d\r\n", module->payload_variant.external_notification.use_i2s_as_buzzer);
       break;
 
       case meshtastic_ModuleConfig_store_forward_tag:
-        Serial.printf("ModuleConfig:store_forward:enabled: %d\r\n", module->payload_variant.store_forward.enabled);
-        Serial.printf("ModuleConfig:store_forward:heartbeat: %d\r\n", module->payload_variant.store_forward.heartbeat);
-        Serial.printf("ModuleConfig:store_forward:history_return_max: %d\r\n", module->payload_variant.store_forward.history_return_max);
-        Serial.printf("ModuleConfig:store_forward:history_return_window: %d\r\n", module->payload_variant.store_forward.history_return_window);
-        Serial.printf("ModuleConfig:store_forward:is_server: %d\r\n", module->payload_variant.store_forward.is_server);
-        Serial.printf("ModuleConfig:store_forward:records: %d\r\n", module->payload_variant.store_forward.records);
+        d("ModuleConfig:store_forward:enabled: %d\r\n", module->payload_variant.store_forward.enabled);
+        d("ModuleConfig:store_forward:heartbeat: %d\r\n", module->payload_variant.store_forward.heartbeat);
+        d("ModuleConfig:store_forward:history_return_max: %d\r\n", module->payload_variant.store_forward.history_return_max);
+        d("ModuleConfig:store_forward:history_return_window: %d\r\n", module->payload_variant.store_forward.history_return_window);
+        d("ModuleConfig:store_forward:is_server: %d\r\n", module->payload_variant.store_forward.is_server);
+        d("ModuleConfig:store_forward:records: %d\r\n", module->payload_variant.store_forward.records);
       break;
 
       case meshtastic_ModuleConfig_range_test_tag: 
-        Serial.printf("ModuleConfig:range_test:enabled: %d\r\n", module->payload_variant.range_test.enabled);
-        Serial.printf("ModuleConfig:range_test:save: %d\r\n", module->payload_variant.range_test.save);
-        Serial.printf("ModuleConfig:range_test:sender: %d\r\n", module->payload_variant.range_test.sender);
+        d("ModuleConfig:range_test:enabled: %d\r\n", module->payload_variant.range_test.enabled);
+        d("ModuleConfig:range_test:save: %d\r\n", module->payload_variant.range_test.save);
+        d("ModuleConfig:range_test:sender: %d\r\n", module->payload_variant.range_test.sender);
       break;
 
       case meshtastic_ModuleConfig_telemetry_tag:
-        Serial.printf("ModuleConfig:telemetry:air_quality_enabled: %d\r\n", module->payload_variant.telemetry.air_quality_enabled);
-        Serial.printf("ModuleConfig:telemetry:air_quality_interval: %d\r\n", module->payload_variant.telemetry.air_quality_interval);
-        Serial.printf("ModuleConfig:telemetry:device_update_interval: %d\r\n", module->payload_variant.telemetry.device_update_interval);
-        Serial.printf("ModuleConfig:telemetry:environment_display_fahrenheit: %d\r\n", module->payload_variant.telemetry.environment_display_fahrenheit);
-        Serial.printf("ModuleConfig:telemetry:environment_measurement_enabled: %d\r\n", module->payload_variant.telemetry.environment_measurement_enabled);
-        Serial.printf("ModuleConfig:telemetry:environment_screen_enabled: %d\r\n", module->payload_variant.telemetry.environment_screen_enabled);
-        Serial.printf("ModuleConfig:telemetry:environment_update_interval: %d\r\n", module->payload_variant.telemetry.environment_update_interval);
-        Serial.printf("ModuleConfig:telemetry:health_measurement_enabled: %d\r\n", module->payload_variant.telemetry.health_measurement_enabled);
-        Serial.printf("ModuleConfig:telemetry:health_screen_enabled: %d\r\n", module->payload_variant.telemetry.health_screen_enabled);
-        Serial.printf("ModuleConfig:telemetry:health_update_interval: %d\r\n", module->payload_variant.telemetry.health_update_interval);
-        Serial.printf("ModuleConfig:telemetry:power_measurement_enabled: %d\r\n", module->payload_variant.telemetry.power_measurement_enabled);
-        Serial.printf("ModuleConfig:telemetry:power_update_interval: %d\r\n", module->payload_variant.telemetry.power_update_interval);
+        d("ModuleConfig:telemetry:air_quality_enabled: %d\r\n", module->payload_variant.telemetry.air_quality_enabled);
+        d("ModuleConfig:telemetry:air_quality_interval: %d\r\n", module->payload_variant.telemetry.air_quality_interval);
+        d("ModuleConfig:telemetry:device_update_interval: %d\r\n", module->payload_variant.telemetry.device_update_interval);
+        d("ModuleConfig:telemetry:environment_display_fahrenheit: %d\r\n", module->payload_variant.telemetry.environment_display_fahrenheit);
+        d("ModuleConfig:telemetry:environment_measurement_enabled: %d\r\n", module->payload_variant.telemetry.environment_measurement_enabled);
+        d("ModuleConfig:telemetry:environment_screen_enabled: %d\r\n", module->payload_variant.telemetry.environment_screen_enabled);
+        d("ModuleConfig:telemetry:environment_update_interval: %d\r\n", module->payload_variant.telemetry.environment_update_interval);
+        d("ModuleConfig:telemetry:health_measurement_enabled: %d\r\n", module->payload_variant.telemetry.health_measurement_enabled);
+        d("ModuleConfig:telemetry:health_screen_enabled: %d\r\n", module->payload_variant.telemetry.health_screen_enabled);
+        d("ModuleConfig:telemetry:health_update_interval: %d\r\n", module->payload_variant.telemetry.health_update_interval);
+        d("ModuleConfig:telemetry:power_measurement_enabled: %d\r\n", module->payload_variant.telemetry.power_measurement_enabled);
+        d("ModuleConfig:telemetry:power_update_interval: %d\r\n", module->payload_variant.telemetry.power_update_interval);
 
       break;
 
       case meshtastic_ModuleConfig_canned_message_tag: 
-        Serial.printf("ModuleConfig:canned_message:enabled: %d\r\n", module->payload_variant.canned_message.enabled);
-        Serial.printf("ModuleConfig:canned_message:allow_input_source: %d\r\n", module->payload_variant.canned_message.allow_input_source);
-        Serial.printf("ModuleConfig:canned_message:inputbroker_event_ccw: %d\r\n", module->payload_variant.canned_message.inputbroker_event_ccw);
-        Serial.printf("ModuleConfig:canned_message:inputbroker_event_cw: %d\r\n", module->payload_variant.canned_message.inputbroker_event_cw);
-        Serial.printf("ModuleConfig:canned_message:inputbroker_event_pass: %d\r\n", module->payload_variant.canned_message.inputbroker_event_press);
-        Serial.printf("ModuleConfig:canned_message:inputbroker_pin_a: %d\r\n", module->payload_variant.canned_message.inputbroker_pin_a);
-        Serial.printf("ModuleConfig:canned_message:inputbroker_pin_b: %d\r\n", module->payload_variant.canned_message.inputbroker_pin_b);
-        Serial.printf("ModuleConfig:canned_message:inputbroker_pin_press: %d\r\n", module->payload_variant.canned_message.inputbroker_pin_press);
-        Serial.printf("ModuleConfig:canned_message:rotary1_enabled: %d\r\n", module->payload_variant.canned_message.rotary1_enabled);
-        Serial.printf("ModuleConfig:canned_message:send_bell: %d\r\n", module->payload_variant.canned_message.send_bell);
-        Serial.printf("ModuleConfig:canned_message:updown1_enabled: %d\r\n", module->payload_variant.canned_message.updown1_enabled);
+        d("ModuleConfig:canned_message:enabled: %d\r\n", module->payload_variant.canned_message.enabled);
+        d("ModuleConfig:canned_message:allow_input_source: %d\r\n", module->payload_variant.canned_message.allow_input_source);
+        d("ModuleConfig:canned_message:inputbroker_event_ccw: %d\r\n", module->payload_variant.canned_message.inputbroker_event_ccw);
+        d("ModuleConfig:canned_message:inputbroker_event_cw: %d\r\n", module->payload_variant.canned_message.inputbroker_event_cw);
+        d("ModuleConfig:canned_message:inputbroker_event_pass: %d\r\n", module->payload_variant.canned_message.inputbroker_event_press);
+        d("ModuleConfig:canned_message:inputbroker_pin_a: %d\r\n", module->payload_variant.canned_message.inputbroker_pin_a);
+        d("ModuleConfig:canned_message:inputbroker_pin_b: %d\r\n", module->payload_variant.canned_message.inputbroker_pin_b);
+        d("ModuleConfig:canned_message:inputbroker_pin_press: %d\r\n", module->payload_variant.canned_message.inputbroker_pin_press);
+        d("ModuleConfig:canned_message:rotary1_enabled: %d\r\n", module->payload_variant.canned_message.rotary1_enabled);
+        d("ModuleConfig:canned_message:send_bell: %d\r\n", module->payload_variant.canned_message.send_bell);
+        d("ModuleConfig:canned_message:updown1_enabled: %d\r\n", module->payload_variant.canned_message.updown1_enabled);
       break;
 
       case meshtastic_ModuleConfig_audio_tag: 
-        Serial.printf("ModuleConfig:audio:codec2_enabled: %d\r\n", module->payload_variant.audio.codec2_enabled);
-        Serial.printf("ModuleConfig:audio:bitrate: %d\r\n", module->payload_variant.audio.bitrate);
-        Serial.printf("ModuleConfig:audio:i2s_din: %d\r\n", module->payload_variant.audio.i2s_din);
-        Serial.printf("ModuleConfig:audio:i2s_sck: %d\r\n", module->payload_variant.audio.i2s_sck);
-        Serial.printf("ModuleConfig:audio:i2s_sd: %d\r\n", module->payload_variant.audio.i2s_sd);
-        Serial.printf("ModuleConfig:audio:i2s_ws: %d\r\n", module->payload_variant.audio.i2s_ws);
-        Serial.printf("ModuleConfig:audio:ptt_pin: %d\r\n", module->payload_variant.audio.ptt_pin);
+        d("ModuleConfig:audio:codec2_enabled: %d\r\n", module->payload_variant.audio.codec2_enabled);
+        d("ModuleConfig:audio:bitrate: %d\r\n", module->payload_variant.audio.bitrate);
+        d("ModuleConfig:audio:i2s_din: %d\r\n", module->payload_variant.audio.i2s_din);
+        d("ModuleConfig:audio:i2s_sck: %d\r\n", module->payload_variant.audio.i2s_sck);
+        d("ModuleConfig:audio:i2s_sd: %d\r\n", module->payload_variant.audio.i2s_sd);
+        d("ModuleConfig:audio:i2s_ws: %d\r\n", module->payload_variant.audio.i2s_ws);
+        d("ModuleConfig:audio:ptt_pin: %d\r\n", module->payload_variant.audio.ptt_pin);
       break;
 
       case meshtastic_ModuleConfig_remote_hardware_tag: 
-        Serial.printf("ModuleConfig:remote_hardware:enabled: %d\r\n", module->payload_variant.remote_hardware.enabled);
-        Serial.printf("ModuleConfig:remote_hardware:allow_undefined_pin_access: %d\r\n", module->payload_variant.remote_hardware.allow_undefined_pin_access);
-        Serial.printf("ModuleConfig:remote_hardware:available_pins: %d\r\n", module->payload_variant.remote_hardware.available_pins);
-        Serial.printf("ModuleConfig:remote_hardware:available_pins_count: %d\r\n", module->payload_variant.remote_hardware.available_pins_count);
+        d("ModuleConfig:remote_hardware:enabled: %d\r\n", module->payload_variant.remote_hardware.enabled);
+        d("ModuleConfig:remote_hardware:allow_undefined_pin_access: %d\r\n", module->payload_variant.remote_hardware.allow_undefined_pin_access);
+        d("ModuleConfig:remote_hardware:available_pins: %d\r\n", module->payload_variant.remote_hardware.available_pins);
+        d("ModuleConfig:remote_hardware:available_pins_count: %d\r\n", module->payload_variant.remote_hardware.available_pins_count);
 
       break;
 
       case meshtastic_ModuleConfig_neighbor_info_tag: 
-        Serial.printf("ModuleConfig:neighbor_info:enabled: %d\r\n", module->payload_variant.neighbor_info.enabled);
-        Serial.printf("ModuleConfig:neighbor_info:transmit_over_lora: %d\r\n", module->payload_variant.neighbor_info.transmit_over_lora);
-        Serial.printf("ModuleConfig:neighbor_info:update_interval: %d\r\n", module->payload_variant.neighbor_info.update_interval);
+        d("ModuleConfig:neighbor_info:enabled: %d\r\n", module->payload_variant.neighbor_info.enabled);
+        d("ModuleConfig:neighbor_info:transmit_over_lora: %d\r\n", module->payload_variant.neighbor_info.transmit_over_lora);
+        d("ModuleConfig:neighbor_info:update_interval: %d\r\n", module->payload_variant.neighbor_info.update_interval);
       break;
 
       case meshtastic_ModuleConfig_ambient_lighting_tag:
-        Serial.printf("ModuleConfig:ambient_lighting:led_state: %d\r\n", module->payload_variant.ambient_lighting.led_state);
-        Serial.printf("ModuleConfig:ambient_lighting:current: %d\r\n", module->payload_variant.ambient_lighting.current);
-        Serial.printf("ModuleConfig:ambient_lighting:red: %d\r\n", module->payload_variant.ambient_lighting.red);
-        Serial.printf("ModuleConfig:ambient_lighting:green: %d\r\n", module->payload_variant.ambient_lighting.green);
-        Serial.printf("ModuleConfig:ambient_lighting:blue: %d\r\n", module->payload_variant.ambient_lighting.blue);
+        d("ModuleConfig:ambient_lighting:led_state: %d\r\n", module->payload_variant.ambient_lighting.led_state);
+        d("ModuleConfig:ambient_lighting:current: %d\r\n", module->payload_variant.ambient_lighting.current);
+        d("ModuleConfig:ambient_lighting:red: %d\r\n", module->payload_variant.ambient_lighting.red);
+        d("ModuleConfig:ambient_lighting:green: %d\r\n", module->payload_variant.ambient_lighting.green);
+        d("ModuleConfig:ambient_lighting:blue: %d\r\n", module->payload_variant.ambient_lighting.blue);
       break;
 
       case meshtastic_ModuleConfig_detection_sensor_tag: 
-        Serial.printf("ModuleConfig:detection_sensor:enabled: %d\r\n", module->payload_variant.detection_sensor.enabled);
-        Serial.printf("ModuleConfig:detection_sensor:detection_trigger_type: %d\r\n", module->payload_variant.detection_sensor.detection_trigger_type);
-        Serial.printf("ModuleConfig:detection_sensor:min_broadcast_secs: %d\r\n", module->payload_variant.detection_sensor.minimum_broadcast_secs);
-        Serial.printf("ModuleConfig:detection_sensor:monitor_pin: %d\r\n", module->payload_variant.detection_sensor.monitor_pin);
-        Serial.printf("ModuleConfig:detection_sensor:name: %d\r\n", module->payload_variant.detection_sensor.name);
-        Serial.printf("ModuleConfig:detection_sensor:send_bell: %d\r\n", module->payload_variant.detection_sensor.send_bell);
-        Serial.printf("ModuleConfig:detection_sensor:state_broadcast_secs: %d\r\n", module->payload_variant.detection_sensor.state_broadcast_secs);
-        Serial.printf("ModuleConfig:detection_sensor:use_pullup: %d\r\n", module->payload_variant.detection_sensor.use_pullup);
+        d("ModuleConfig:detection_sensor:enabled: %d\r\n", module->payload_variant.detection_sensor.enabled);
+        d("ModuleConfig:detection_sensor:detection_trigger_type: %d\r\n", module->payload_variant.detection_sensor.detection_trigger_type);
+        d("ModuleConfig:detection_sensor:min_broadcast_secs: %d\r\n", module->payload_variant.detection_sensor.minimum_broadcast_secs);
+        d("ModuleConfig:detection_sensor:monitor_pin: %d\r\n", module->payload_variant.detection_sensor.monitor_pin);
+        d("ModuleConfig:detection_sensor:name: %d\r\n", module->payload_variant.detection_sensor.name);
+        d("ModuleConfig:detection_sensor:send_bell: %d\r\n", module->payload_variant.detection_sensor.send_bell);
+        d("ModuleConfig:detection_sensor:state_broadcast_secs: %d\r\n", module->payload_variant.detection_sensor.state_broadcast_secs);
+        d("ModuleConfig:detection_sensor:use_pullup: %d\r\n", module->payload_variant.detection_sensor.use_pullup);
       break;
 
       case meshtastic_ModuleConfig_paxcounter_tag:
-        Serial.printf("ModuleConfig:paxcounter:enabled: %d\r\n", module->payload_variant.paxcounter.enabled);
-        Serial.printf("ModuleConfig:paxcounter:ble_threshold: %d\r\n", module->payload_variant.paxcounter.ble_threshold);
-        Serial.printf("ModuleConfig:paxcounter:paxcounter_update_interval: %d\r\n", module->payload_variant.paxcounter.paxcounter_update_interval);
-        Serial.printf("ModuleConfig:paxcounter:wifi_threshold: %d\r\n", module->payload_variant.paxcounter.wifi_threshold);
+        d("ModuleConfig:paxcounter:enabled: %d\r\n", module->payload_variant.paxcounter.enabled);
+        d("ModuleConfig:paxcounter:ble_threshold: %d\r\n", module->payload_variant.paxcounter.ble_threshold);
+        d("ModuleConfig:paxcounter:paxcounter_update_interval: %d\r\n", module->payload_variant.paxcounter.paxcounter_update_interval);
+        d("ModuleConfig:paxcounter:wifi_threshold: %d\r\n", module->payload_variant.paxcounter.wifi_threshold);
       break;
 
       default:
-        Serial.printf("Unknown payload variant: %d\r\n", module->which_payload_variant);
+        d("Unknown payload variant: %d\r\n", module->which_payload_variant);
   }
   return true;
 }
 
 bool handle_queueStatus_tag(meshtastic_QueueStatus *qstatus) {
-  Serial.printf("queueStatus: maxlen: %d\r\n", qstatus->maxlen);
-  Serial.printf("queueStatus: res: %d\r\n", qstatus->res);
-  Serial.printf("queueStatus: free: %d\r\n", qstatus->free);
-  Serial.printf("queueStatus: mesh_packet_id: %d\r\n", qstatus->mesh_packet_id);
+  d("queueStatus: maxlen: %d\r\n", qstatus->maxlen);
+  d("queueStatus: res: %d\r\n", qstatus->res);
+  d("queueStatus: free: %d\r\n", qstatus->free);
+  d("queueStatus: mesh_packet_id: %d\r\n", qstatus->mesh_packet_id);
   return true;
 }
 
 bool handle_xmodemPacket_tag(meshtastic_XModem *packet) {
-  Serial.printf("XmodemPacket: XModem control #: %d\r\n", packet->control);
-  Serial.printf("XmodemPacket: XModem sequence #: %d\r\n", packet->seq);
-  Serial.printf("XmodemPacket: XModem crc16: %d\r\n", packet->crc16);
+  d("XmodemPacket: XModem control #: %d\r\n", packet->control);
+  d("XmodemPacket: XModem sequence #: %d\r\n", packet->seq);
+  d("XmodemPacket: XModem crc16: %d\r\n", packet->crc16);
   return true;
 }
 
 bool handle_metatag_data(meshtastic_DeviceMetadata *meta) {
-  Serial.printf("metatag_data:FW Version: %s\r\n", meta->firmware_version);
-  Serial.printf("metatag_data:device_state_version: %d\r\n", meta->device_state_version);
-  Serial.printf("metatag_data:canShutdown: %d\r\n", meta->canShutdown);
-  Serial.printf("metatag_data:hasWiFi: %d\r\n", meta->hasWifi);
-  Serial.printf("metatag_data:hasBluetooth: %d\r\n", meta->hasBluetooth);
-  Serial.printf("metatag_data:hasEthernet: %d\r\n", meta->hasEthernet);
-  Serial.printf("metatag_data:role: %d\r\n", meta->role);
-  Serial.printf("metatag_data:positionFlags: %d\r\n", meta->position_flags);
-  Serial.printf("metatag_data:hw_model: %d\r\n", meta->hw_model);
-  Serial.printf("metatag_data:hasRemoteHardware: %d\r\n", meta->hasRemoteHardware);
-  Serial.printf("metatag_data:excludedModules: %d\r\n", meta->excluded_modules);
+  d("metatag_data:FW Version: %s\r\n", meta->firmware_version);
+  d("metatag_data:device_state_version: %d\r\n", meta->device_state_version);
+  d("metatag_data:canShutdown: %d\r\n", meta->canShutdown);
+  d("metatag_data:hasWiFi: %d\r\n", meta->hasWifi);
+  d("metatag_data:hasBluetooth: %d\r\n", meta->hasBluetooth);
+  d("metatag_data:hasEthernet: %d\r\n", meta->hasEthernet);
+  d("metatag_data:role: %d\r\n", meta->role);
+  d("metatag_data:positionFlags: %d\r\n", meta->position_flags);
+  d("metatag_data:hw_model: %d\r\n", meta->hw_model);
+  d("metatag_data:hasRemoteHardware: %d\r\n", meta->hasRemoteHardware);
+  d("metatag_data:excludedModules: %d\r\n", meta->excluded_modules);
   return true;
 }
 
 bool handle_mqttClientProxyMessage_tag(meshtastic_MqttClientProxyMessage *mqtt) {
-  Serial.printf("mqttClientProxyMessage:Topic: %s\r\n", mqtt->topic);
+  d("mqttClientProxyMessage:Topic: %s\r\n", mqtt->topic);
   switch (mqtt->which_payload_variant) {
     case meshtastic_MqttClientProxyMessage_data_tag:
-      // TODO - INVALID Serial.printf("mqttClientProxyMessage:data: %s\r\n", mqtt->payload_variant.data);
+      // TODO - INVALID d("mqttClientProxyMessage:data: %s\r\n", mqtt->payload_variant.data);
       break;
     case meshtastic_MqttClientProxyMessage_text_tag:
-      Serial.printf("mqttClientProxyMessage:text %s\r\n", mqtt->payload_variant.text);
+      d("mqttClientProxyMessage:text %s\r\n", mqtt->payload_variant.text);
       break;
   }
-  Serial.printf("mqttClientProxyMessage:retained: %d\r\n", mqtt->retained);
+  d("mqttClientProxyMessage:retained: %d\r\n", mqtt->retained);
   return true;
 }
 
 bool handle_fileInfo_tag(meshtastic_FileInfo *fInfo) {
-  Serial.printf("fileInfo:fileName: %s\r\n", fInfo->file_name);
-  Serial.printf("fileInfo:sizeBytes: %d\r\n", fInfo->size_bytes);
+  d("fileInfo:fileName: %s\r\n", fInfo->file_name);
+  d("fileInfo:sizeBytes: %d\r\n", fInfo->size_bytes);
   return true;
 }
 
@@ -607,11 +614,11 @@ bool handle_mesh_packet(meshtastic_MeshPacket *meshPacket) {
         break;
 
       default:
-          Serial.printf("Unknown portnum %d\r\n", meshPacket->decoded.portnum);
+          d("Unknown portnum %d\r\n", meshPacket->decoded.portnum);
             return false;
     }
   } else if  (meshPacket -> which_payload_variant == meshtastic_MeshPacket_encrypted_tag ) {
-      Serial.printf("encoded packet From: %x To: %x\r\n", meshPacket->from, meshPacket->to);
+      d("encoded packet From: %x To: %x\r\n", meshPacket->from, meshPacket->to);
       if (encrypted_callback != NULL) {
           encrypted_callback(meshPacket->from, meshPacket->to, meshPacket->channel, meshPacket->public_key, &meshPacket->encrypted);
     	    return true;

--- a/src/mt_protocol.cpp
+++ b/src/mt_protocol.cpp
@@ -138,6 +138,10 @@ bool mt_send_heartbeat() {
 
 }
 
+void set_xxx_callback(void (*callback)(uint32_t from, uint32_t to,  uint8_t channel, const char* text)) {
+  xxx_callback = callback;
+}
+
 void set_text_message_callback(void (*callback)(uint32_t from, uint32_t to,  uint8_t channel, const char* text)) {
   text_message_callback = callback;
 }
@@ -557,15 +561,21 @@ bool handle_config_complete_id(uint32_t now, uint32_t config_complete_id) {
 
 bool handle_mesh_packet(meshtastic_MeshPacket *meshPacket) {
   if (meshPacket->which_payload_variant == meshtastic_MeshPacket_decoded_tag) {
-    if (meshPacket->decoded.portnum == meshtastic_PortNum_TEXT_MESSAGE_APP) {
-      if (text_message_callback != NULL)
-        text_message_callback(meshPacket->from, meshPacket->to, meshPacket->channel, (const char*)meshPacket->decoded.payload.bytes);
-    } else {
-      // TODO handle other portnums
-      return false;
-    }
+	switch (meshPacket->decoded.portnum) {
+    	case meshtastic_PortNum_TEXT_MESSAGE_APP:
+      		if (text_message_callback != NULL) {
+        		text_message_callback(meshPacket->from, meshPacket->to, meshPacket->channel, (const char*)meshPacket->decoded.payload.bytes);
+    		} else {
+			}
+			break;
+		case meshtastic_PortNum_XXX:
+
+		default;
+    		d("Unknown portnum");
+      		return false;
+	}
   } else {
-    return false;
+    	return false;
   }
   return true;
 }

--- a/src/mt_protocol.cpp
+++ b/src/mt_protocol.cpp
@@ -143,52 +143,52 @@ void set_text_message_callback(void (*callback)(uint32_t from, uint32_t to,  uin
 }
 
 bool handle_id_tag(uint32_t id) {
-  Serial.printf("Handle_id_tag: %d\n", id);
+  Serial.printf("Handle_id_tag: %d\r\n", id);
   return true;
 }
 
 bool handle_config_tag(meshtastic_Config *config) {
-  Serial.printf("Handle_config_tag: Payload Variant: %d\n", config->which_payload_variant);
+  Serial.printf("Handle_config_tag: Payload Variant: %d\r\n", config->which_payload_variant);
   return true;
 }
 
 bool handle_channel_tag(meshtastic_Channel *channel) {
-  Serial.printf("Handle_channel_tag %d\n", channel->index);
+  Serial.printf("Handle_channel_tag %d\r\n", channel->index);
   return true;
 }
 
 bool handle_FromRadio_log_record_tag(meshtastic_LogRecord *record) {
-  Serial.printf("Handle_FromRadio_log_record_tag %s\n", record->message);
+  Serial.printf("Handle_FromRadio_log_record_tag %s\r\n", record->message);
   return true;
 }
 
 bool handle_moduleConfig_tag(meshtastic_ModuleConfig *module){ 
-  Serial.printf("Handle_moduleConfig_tag PayloadVariant: %d\n", module->which_payload_variant);
+  Serial.printf("Handle_moduleConfig_tag PayloadVariant: %d\r\n", module->which_payload_variant);
   return true;
 }
 
 bool handle_queueStatus_tag(meshtastic_QueueStatus *qstatus) {
-  Serial.printf("Handle_queueStatus_tag maxlen: %d\n", qstatus->maxlen);
+  Serial.printf("Handle_queueStatus_tag maxlen: %d\r\n", qstatus->maxlen);
   return true;
 }
 
 bool handle_xmodemPacket_tag(meshtastic_XModem *packet) {
-  Serial.printf("Handle_xmodem_tag XModem Sequence # %d\n", packet->seq);
+  Serial.printf("Handle_xmodem_tag XModem Sequence # %d\r\n", packet->seq);
   return true;
 }
 
 bool handle_metatag_data(meshtastic_DeviceMetadata *meta) {
-  Serial.printf("Handle_metatag_data FW Version: %s\n", meta->firmware_version);
+  Serial.printf("Handle_metatag_data FW Version: %s\r\n", meta->firmware_version);
   return true;
 }
 
 bool handle_mqttClientProxyMessage_tag(meshtastic_MqttClientProxyMessage *mqtt) {
-  Serial.printf("Handle_mqttClientProxyMessage_tag Topic: %s\n", mqtt->topic);
+  Serial.printf("Handle_mqttClientProxyMessage_tag Topic: %s\r\n", mqtt->topic);
   return true;
 }
 
 bool handle_fileInfo_tag(meshtastic_FileInfo *fInfo) {
-  Serial.printf("Handle_fileInfo_tag FileName: %s\n", fInfo->file_name);
+  Serial.printf("Handle_fileInfo_tag FileName: %s\r\n", fInfo->file_name);
   return true;
 }
 

--- a/src/mt_protocol.cpp
+++ b/src/mt_protocol.cpp
@@ -143,12 +143,116 @@ void set_text_message_callback(void (*callback)(uint32_t from, uint32_t to,  uin
 }
 
 bool handle_id_tag(uint32_t id) {
-  Serial.printf("Handle_id_tag: %d\r\n", id);
+  Serial.printf("Handle_id_tag: ID: %d\r\n", id);
   return true;
 }
 
 bool handle_config_tag(meshtastic_Config *config) {
-  Serial.printf("Handle_config_tag: Payload Variant: %d\r\n", config->which_payload_variant);
+  switch (config->which_payload_variant) {
+    case meshtastic_Config_device_tag:
+      Serial.printf("Config:device_tag:  role: %d\r\n", config->payload_variant.device.role);
+      Serial.printf("Config:device_tag:  serial enabled: %d\r\n", config->payload_variant.device.serial_enabled);
+      Serial.printf("Config:device_tag:  button gpio: %d\r\n", config->payload_variant.device.button_gpio);
+      Serial.printf("Config:device_tag:  buzzer gpio: %d\r\n", config->payload_variant.device.buzzer_gpio);
+      Serial.printf("Config:device_tag:  rebroadcast mode: %d\r\n", config->payload_variant.device.rebroadcast_mode);
+      Serial.printf("Config:device_tag:  node_info_broadcast_secs: %d\r\n", config->payload_variant.device.node_info_broadcast_secs);
+      Serial.printf("Config:device_tag:  double-tap-as-button-press: %d\r\n", config->payload_variant.device.double_tap_as_button_press);
+      Serial.printf("Config:device_tag:  is_managed: %d\r\n", config->payload_variant.device.is_managed);
+      Serial.printf("Config:device_tag:  disable_triple_click: %d\r\n", config->payload_variant.device.disable_triple_click);
+      Serial.printf("Config:device_tag:  tz_def: %s\r\n", config->payload_variant.device.tzdef);
+      Serial.printf("Config:device_tag:  led_heartbeat_disabled: %d\r\n", config->payload_variant.device.led_heartbeat_disabled);
+      break;
+
+    case meshtastic_Config_position_tag:
+      Serial.printf("Config:position_tag:  position_broadcast_secs: %d\r\n", config->payload_variant.position.position_broadcast_secs);
+      Serial.printf("Config:position_tag:  position_broadcast_smart_enabled: %d\r\n", config->payload_variant.position.position_broadcast_smart_enabled);
+      Serial.printf("Config:position_tag:  fixed_position: %d\r\n", config->payload_variant.position.fixed_position);
+      Serial.printf("Config:position_tag:  gps_enabled: %d\r\n", config->payload_variant.position.gps_enabled);
+      Serial.printf("Config:position_tag:  gps_update_interval: %d\r\n", config->payload_variant.position.gps_update_interval);
+      Serial.printf("Config:position_tag:  gps_attempt_time: %d\r\n", config->payload_variant.position.gps_attempt_time);
+      Serial.printf("Config:position_tag:  position_flags: %d\r\n", config->payload_variant.position.position_flags);
+      Serial.printf("Config:position_tag:  rx_gpio: %d\r\n", config->payload_variant.position.rx_gpio);
+      Serial.printf("Config:position_tag:  tx_gpio: %d\r\n", config->payload_variant.position.tx_gpio);
+      Serial.printf("Config:position_tag:  broadcast_smart_min_distance: %d\r\n", config->payload_variant.position.broadcast_smart_minimum_distance);
+      Serial.printf("Config:position_tag:  broadcast_smart_min_interval_secs: %d\r\n", config->payload_variant.position.broadcast_smart_minimum_interval_secs);
+      Serial.printf("Config:position_tag:  gps_en_gpio: %d\r\n", config->payload_variant.position.gps_en_gpio);
+      Serial.printf("Config:position_tag:  gps_mode %d\r\n", config->payload_variant.position.gps_mode);
+      break;
+
+    case meshtastic_Config_power_tag: 
+      Serial.printf("Config:power_tag:  is_power_saving %d\r\n", config->payload_variant.power.is_power_saving);
+      Serial.printf("Config:power_tag:  on_battery_shutdown_after_secs %d\r\n", config->payload_variant.power.on_battery_shutdown_after_secs);
+      Serial.printf("Config:power_tag:  adv_multiplier_override %f\r\n", config->payload_variant.power.adc_multiplier_override);
+      Serial.printf("Config:power_tag:  wait_bluetooth_secs %d\r\n", config->payload_variant.power.wait_bluetooth_secs);
+      Serial.printf("Config:power_tag:  sds_secs %d\r\n", config->payload_variant.power.sds_secs);
+      Serial.printf("Config:power_tag:  ls_secs %d\r\n", config->payload_variant.power.ls_secs);
+      Serial.printf("Config:power_tag:  min_wake_secs %d\r\n", config->payload_variant.power.min_wake_secs);
+      Serial.printf("Config:power_tag:  device_battery_ina_aaddr %d\r\n", config->payload_variant.power.device_battery_ina_address);
+      Serial.printf("Config:power_tag:  powermon_enables %d\r\n", config->payload_variant.power.powermon_enables);
+      break;
+
+    case meshtastic_Config_network_tag:
+      Serial.printf("Config:network_tag:wifi_enabled: %d  \r\n", config->payload_variant.network.wifi_enabled);
+      Serial.printf("Config:network_tag:wifi_ssid: %s  \r\n", config->payload_variant.network.wifi_ssid);
+      Serial.printf("Config:network_tag:wifi_psk: %s  \r\n", config->payload_variant.network.wifi_psk);
+      Serial.printf("Config:network_tag:ntp_server: %s  \r\n", config->payload_variant.network.ntp_server);
+      Serial.printf("Config:network_tag:eth_enabled: %d  \r\n", config->payload_variant.network.eth_enabled);
+      Serial.printf("Config:network_tag:addr_mode: %d  \r\n", config->payload_variant.network.address_mode);
+      Serial.printf("Config:network_tag:has_ipv4_config: %d  \r\n", config->payload_variant.network.has_ipv4_config);
+      Serial.printf("Config:network_tag:ipv4_config: %d  \r\n", config->payload_variant.network.ipv4_config);
+      Serial.printf("Config:network_tag:rsyslog_server: %s  \r\n", config->payload_variant.network.rsyslog_server);
+      break;
+
+    case meshtastic_Config_display_tag: 
+      Serial.printf("Config:display_tag:screen_on_seconds: %d  \r\n", config->payload_variant.display.screen_on_secs);
+      Serial.printf("Config:display_tag:gps_format: %d  \r\n", config->payload_variant.display.gps_format);
+      Serial.printf("Config:display_tag:auto_screen_carousel_secs: %d  \r\n", config->payload_variant.display.auto_screen_carousel_secs);
+      Serial.printf("Config:display_tag:compass_north_top: %d  \r\n", config->payload_variant.display.compass_north_top);
+      Serial.printf("Config:display_tag:flip_screen: %d  \r\n", config->payload_variant.display.flip_screen);
+      Serial.printf("Config:display_tag:units: %d  \r\n", config->payload_variant.display.units);
+      Serial.printf("Config:display_tag:oled: %d  \r\n", config->payload_variant.display.oled);
+      Serial.printf("Config:display_tag:displayMode: %d  \r\n", config->payload_variant.display.displaymode);
+      Serial.printf("Config:display_tag:heading_bold: %d  \r\n", config->payload_variant.display.heading_bold);
+      Serial.printf("Config:display_tag:wake_on_tap_or_motion: %d  \r\n", config->payload_variant.display.wake_on_tap_or_motion);
+      Serial.printf("Config:display_tag:compass_orientation: %d  \r\n", config->payload_variant.display.compass_orientation);
+      break;
+
+    case meshtastic_Config_lora_tag:
+      Serial.printf("Config:lora_tag:use_preset: %d  \r\n", config->payload_variant.lora.use_preset);
+      Serial.printf("Config:lora_tag:modem_preset: %d  \r\n", config->payload_variant.lora.modem_preset);
+      Serial.printf("Config:lora_tag:bandwidth: %d  \r\n", config->payload_variant.lora.bandwidth);
+      Serial.printf("Config:lora_tag:spread_factor: %d  \r\n", config->payload_variant.lora.spread_factor);
+      Serial.printf("Config:lora_tag:coding_rate: %d  \r\n", config->payload_variant.lora.coding_rate);
+      Serial.printf("Config:lora_tag:frequency_offset: %d  \r\n", config->payload_variant.lora.frequency_offset);
+      Serial.printf("Config:lora_tag:region: %d  \r\n", config->payload_variant.lora.region);
+      Serial.printf("Config:lora_tag:hot_limit: %d  \r\n", config->payload_variant.lora.hop_limit);
+      Serial.printf("Config:lora_tag:tx_enabled: %d  \r\n", config->payload_variant.lora.tx_enabled);
+      Serial.printf("Config:lora_tag:tx_power: %d  \r\n", config->payload_variant.lora.tx_power);
+      Serial.printf("Config:lora_tag:channel_num: %d  \r\n", config->payload_variant.lora.channel_num);
+      Serial.printf("Config:lora_tag:override_duty_cycle: %d  \r\n", config->payload_variant.lora.override_duty_cycle);
+      Serial.printf("Config:lora_tag:sx126x_rx_boosted_gain: %d  \r\n", config->payload_variant.lora.sx126x_rx_boosted_gain);
+      Serial.printf("Config:lora_tag:override_frequency: %d  \r\n", config->payload_variant.lora.override_frequency);
+      Serial.printf("Config:lora_tag:pa_fan_disabled: %d  \r\n", config->payload_variant.lora.pa_fan_disabled);
+      Serial.printf("Config:lora_tag:ignore_incoming_count: %d  \r\n", config->payload_variant.lora.ignore_incoming_count);
+      Serial.printf("Config:lora_tag:ignore_mqtt: %d  \r\n", config->payload_variant.lora.ignore_mqtt);
+      Serial.printf("Config:lora_tag:config_okay_to_mqtt: %d  \r\n", config->payload_variant.lora.config_ok_to_mqtt);
+      break;
+
+    case meshtastic_Config_bluetooth_tag: 
+      Serial.printf("Config:bluetooth_tag:  \r\n");
+      break;
+
+    case meshtastic_Config_security_tag: 
+      Serial.printf("Config:security_tag:  \r\n");
+      break;
+
+    case meshtastic_Config_sessionkey_tag: 
+      Serial.printf("Config:sessionkey_tag:  \r\n");
+      break;
+
+    default:
+      Serial.printf("Unknown Config_Tag payload variant: %d\r\n", config->which_payload_variant);
+  }
   return true;
 }
 
@@ -163,7 +267,59 @@ bool handle_FromRadio_log_record_tag(meshtastic_LogRecord *record) {
 }
 
 bool handle_moduleConfig_tag(meshtastic_ModuleConfig *module){ 
-  Serial.printf("Handle_moduleConfig_tag PayloadVariant: %d\r\n", module->which_payload_variant);
+  switch (module->which_payload_variant) {
+      case meshtastic_ModuleConfig_mqtt_tag:
+      Serial.printf("ModuleConfig:mqtt:enabled: %d\r\n", module->payload_variant.mqtt.enabled);
+      Serial.printf("ModuleConfig:mqtt:address: %s\r\n", module->payload_variant.mqtt.address);
+      Serial.printf("ModuleConfig:mqtt:username: %s\r\n", module->payload_variant.mqtt.username);
+      Serial.printf("ModuleConfig:mqtt:password: %s\r\n", module->payload_variant.mqtt.password);
+      Serial.printf("ModuleConfig:mqtt:encryption_enabled: %d\r\n", module->payload_variant.mqtt.encryption_enabled);
+      Serial.printf("ModuleConfig:mqtt:json_enabled: %d\r\n", module->payload_variant.mqtt.json_enabled);
+      Serial.printf("ModuleConfig:mqtt:root: %s\r\n", module->payload_variant.mqtt.root);
+      Serial.printf("ModuleConfig:mqtt:proxy_to_client_enabled: %d\r\n", module->payload_variant.mqtt.proxy_to_client_enabled);
+      Serial.printf("ModuleConfig:mqtt:map_reporting_enabled %d\r\n", module->payload_variant.mqtt.map_report_settings);
+      Serial.printf("ModuleConfig:mqtt:has_map_report_settings%d\r\n", module->payload_variant.mqtt.has_map_report_settings);
+      break;
+
+      case meshtastic_ModuleConfig_serial_tag:
+      break;
+
+      case meshtastic_ModuleConfig_external_notification_tag:
+      break;
+
+      case meshtastic_ModuleConfig_store_forward_tag:
+      break;
+
+      case meshtastic_ModuleConfig_range_test_tag: 
+      break;
+
+      case meshtastic_ModuleConfig_telemetry_tag:
+      break;
+
+      case meshtastic_ModuleConfig_canned_message_tag: 
+      break;
+
+      case meshtastic_ModuleConfig_audio_tag: 
+      break;
+
+      case meshtastic_ModuleConfig_remote_hardware_tag: 
+      break;
+
+      case meshtastic_ModuleConfig_neighbor_info_tag: 
+      break;
+
+      case meshtastic_ModuleConfig_ambient_lighting_tag:
+      break;
+
+      case meshtastic_ModuleConfig_detection_sensor_tag: 
+      break;
+
+      case meshtastic_ModuleConfig_paxcounter_tag:
+      break;
+
+      default:
+        Serial.printf("Unknown payload variant: %d\r\n", module->which_payload_variant);
+  }
   return true;
 }
 

--- a/src/mt_protocol.cpp
+++ b/src/mt_protocol.cpp
@@ -143,7 +143,7 @@ void set_text_message_callback(void (*callback)(uint32_t from, uint32_t to,  uin
 }
 
 bool handle_id_tag(uint32_t id) {
-  Serial.printf("Handle_id_tag: ID: %d\r\n", id);
+  Serial.printf("id_tag: ID: %d\r\n", id);
   return true;
 }
 
@@ -239,15 +239,38 @@ bool handle_config_tag(meshtastic_Config *config) {
       break;
 
     case meshtastic_Config_bluetooth_tag: 
-      Serial.printf("Config:bluetooth_tag:  \r\n");
+      Serial.printf("Config:bluetooth_tag:enabled: %d  \r\n", config->payload_variant.bluetooth.enabled);
+      Serial.printf("Config:bluetooth_tag:fixed_pin: %d  \r\n", config->payload_variant.bluetooth.fixed_pin);
+      Serial.printf("Config:bluetooth_tag:mode: %d  \r\n", config->payload_variant.bluetooth.mode);
       break;
 
     case meshtastic_Config_security_tag: 
-      Serial.printf("Config:security_tag:  \r\n");
+      Serial.printf("Config:security_tag:is_managed: %d \r\n", config->payload_variant.security.is_managed);
+      Serial.printf("Config:security_tag:public_key: %x \r\n", config->payload_variant.security.public_key);
+      Serial.printf("Config:security_tag:private_key: %x \r\n", config->payload_variant.security.private_key);
+      Serial.printf("Config:security_tag:admin_key_count: %x \r\n", config->payload_variant.security.admin_key_count);
+      Serial.printf("Config:security_tag:serial_enabled: %x \r\n", config->payload_variant.security.serial_enabled);
+      Serial.printf("Config:security_tag:debug_log_api_enabled: %x \r\n", config->payload_variant.security.debug_log_api_enabled);
+      Serial.printf("Config:security_tag:admin_channel_enabled: %x \r\n", config->payload_variant.security.admin_channel_enabled);
       break;
 
     case meshtastic_Config_sessionkey_tag: 
-      Serial.printf("Config:sessionkey_tag:  \r\n");
+      Serial.printf("Config:sessionkey_tag:dummy_field: %x \r\n", config->payload_variant.sessionkey.dummy_field);
+      break;
+
+    case meshtastic_Config_device_ui_tag:
+      Serial.printf("Config.device_ui:alert_enabled: %d\r\n", config->payload_variant.device_ui.alert_enabled);
+      Serial.printf("Config.device_ui:banner_enabled: %d\r\n", config->payload_variant.device_ui.banner_enabled);
+      Serial.printf("Config.device_ui:has_node_filter: %d\r\n", config->payload_variant.device_ui.has_node_filter);
+      Serial.printf("Config.device_ui:has_node_highlight: %d\r\n", config->payload_variant.device_ui.has_node_highlight);
+      Serial.printf("Config.device_ui:language: %d\r\n", config->payload_variant.device_ui.language);
+      Serial.printf("Config.device_ui:node_filter: %d\r\n", config->payload_variant.device_ui.node_filter);
+      Serial.printf("Config.device_ui:node_highlight: %d\r\n", config->payload_variant.device_ui.node_highlight);
+      Serial.printf("Config.device_ui:pin_code: %d\r\n", config->payload_variant.device_ui.pin_code);
+      Serial.printf("Config.device_ui:ring_tone_id: %d\r\n", config->payload_variant.device_ui.ring_tone_id);
+      Serial.printf("Config.device_ui:screen_brightness: %d\r\n", config->payload_variant.device_ui.screen_brightness);
+      Serial.printf("Config.device_ui:screen_lock: %d\r\n", config->payload_variant.device_ui.screen_lock);
+      Serial.printf("Config.device_ui:screen_timeout: %d\r\n", config->payload_variant.device_ui.screen_timeout);
       break;
 
     default:
@@ -257,12 +280,17 @@ bool handle_config_tag(meshtastic_Config *config) {
 }
 
 bool handle_channel_tag(meshtastic_Channel *channel) {
-  Serial.printf("Handle_channel_tag %d\r\n", channel->index);
+  Serial.printf("ChannelTag:index: %d\r\n", channel->index);
+  Serial.printf("ChannelTag:has_settings: %d\r\n", channel->has_settings);
+  Serial.printf("ChannelTag:role: %d\r\n", channel->role);
   return true;
 }
 
 bool handle_FromRadio_log_record_tag(meshtastic_LogRecord *record) {
-  Serial.printf("Handle_FromRadio_log_record_tag %s\r\n", record->message);
+  Serial.printf("FromRadio_log_record:message: %s\r\n", record->message);
+  Serial.printf("FromRadio_log_record:time: %d\r\n", record->time);
+  Serial.printf("FromRadio_log_record:source: %s\r\n", record->source);
+  Serial.printf("FromRadio_log_record:level: %s\r\n", record->level);
   return true;
 }
 
@@ -278,43 +306,131 @@ bool handle_moduleConfig_tag(meshtastic_ModuleConfig *module){
       Serial.printf("ModuleConfig:mqtt:root: %s\r\n", module->payload_variant.mqtt.root);
       Serial.printf("ModuleConfig:mqtt:proxy_to_client_enabled: %d\r\n", module->payload_variant.mqtt.proxy_to_client_enabled);
       Serial.printf("ModuleConfig:mqtt:map_reporting_enabled %d\r\n", module->payload_variant.mqtt.map_report_settings);
-      Serial.printf("ModuleConfig:mqtt:has_map_report_settings%d\r\n", module->payload_variant.mqtt.has_map_report_settings);
+      Serial.printf("ModuleConfig:mqtt:has_map_report_settings %d\r\n", module->payload_variant.mqtt.has_map_report_settings);
       break;
 
       case meshtastic_ModuleConfig_serial_tag:
+        Serial.printf("ModuleConfig:serial:enabled: %d\r\n", module->payload_variant.serial.enabled);
+        Serial.printf("ModuleConfig:serial:echo: %d\r\n", module->payload_variant.serial.echo);
+        Serial.printf("ModuleConfig:serial:rxd-gpio-pin: %d\r\n", module->payload_variant.serial.rxd);
+        Serial.printf("ModuleConfig:serial:txd-gpio-pin: %d\r\n", module->payload_variant.serial.txd);
+        Serial.printf("ModuleConfig:serial:baud: %d\r\n", module->payload_variant.serial.baud);
+        Serial.printf("ModuleConfig:serial:timeout: %d\r\n", module->payload_variant.serial.timeout);
+        Serial.printf("ModuleConfig:serial:mode: %d\r\n", module->payload_variant.serial.mode);
+        Serial.printf("ModuleConfig:serial:override_console_serial_port: %d\r\n", module->payload_variant.serial.override_console_serial_port);
       break;
 
       case meshtastic_ModuleConfig_external_notification_tag:
+        Serial.printf("ModuleConfig:external_notification:enabled: %d\r\n", module->payload_variant.external_notification.enabled);
+        Serial.printf("ModuleConfig:external_notification:output_ms: %d\r\n", module->payload_variant.external_notification.output_ms);
+        Serial.printf("ModuleConfig:external_notification:output: %d\r\n", module->payload_variant.external_notification.output);
+        Serial.printf("ModuleConfig:external_notification:active: %d\r\n", module->payload_variant.external_notification.active);
+        Serial.printf("ModuleConfig:external_notification:alert_message: %d\r\n", module->payload_variant.external_notification.alert_message);
+        Serial.printf("ModuleConfig:external_notification:alert_bell: %d\r\n", module->payload_variant.external_notification.alert_bell);
+        Serial.printf("ModuleConfig:external_notification:use_pwm: %d\r\n", module->payload_variant.external_notification.use_pwm);
+        Serial.printf("ModuleConfig:external_notification:output_vibra: %d\r\n", module->payload_variant.external_notification.output_vibra);
+        Serial.printf("ModuleConfig:external_notification:output_buzzer: %d\r\n", module->payload_variant.external_notification.output_buzzer);
+        Serial.printf("ModuleConfig:external_notification:alert_message_vibra: %d\r\n", module->payload_variant.external_notification.alert_message_vibra);
+        Serial.printf("ModuleConfig:external_notification:alert_message_buzzer: %d\r\n", module->payload_variant.external_notification.alert_message_buzzer);
+        Serial.printf("ModuleConfig:external_notification:alert_bell_vibra: %d\r\n", module->payload_variant.external_notification.alert_bell_vibra);
+        Serial.printf("ModuleConfig:external_notification:alert_bell_buzzer: %d\r\n", module->payload_variant.external_notification.alert_bell_buzzer);
+        Serial.printf("ModuleConfig:external_notification:nag_timeout: %d\r\n", module->payload_variant.external_notification.nag_timeout);
+        Serial.printf("ModuleConfig:external_notification:use_i2s_as_buzzer: %d\r\n", module->payload_variant.external_notification.use_i2s_as_buzzer);
       break;
 
       case meshtastic_ModuleConfig_store_forward_tag:
+        Serial.printf("ModuleConfig:store_forward:enabled: %d\r\n", module->payload_variant.store_forward.enabled);
+        Serial.printf("ModuleConfig:store_forward:heartbeat: %d\r\n", module->payload_variant.store_forward.heartbeat);
+        Serial.printf("ModuleConfig:store_forward:history_return_max: %d\r\n", module->payload_variant.store_forward.history_return_max);
+        Serial.printf("ModuleConfig:store_forward:history_return_window: %d\r\n", module->payload_variant.store_forward.history_return_window);
+        Serial.printf("ModuleConfig:store_forward:is_server: %d\r\n", module->payload_variant.store_forward.is_server);
+        Serial.printf("ModuleConfig:store_forward:records: %d\r\n", module->payload_variant.store_forward.records);
       break;
 
       case meshtastic_ModuleConfig_range_test_tag: 
+        Serial.printf("ModuleConfig:range_test:enabled: %d\r\n", module->payload_variant.range_test.enabled);
+        Serial.printf("ModuleConfig:range_test:save: %d\r\n", module->payload_variant.range_test.save);
+        Serial.printf("ModuleConfig:range_test:sender: %d\r\n", module->payload_variant.range_test.sender);
       break;
 
       case meshtastic_ModuleConfig_telemetry_tag:
+        Serial.printf("ModuleConfig:telemetry:air_quality_enabled: %d\r\n", module->payload_variant.telemetry.air_quality_enabled);
+        Serial.printf("ModuleConfig:telemetry:air_quality_interval: %d\r\n", module->payload_variant.telemetry.air_quality_interval);
+        Serial.printf("ModuleConfig:telemetry:device_update_interval: %d\r\n", module->payload_variant.telemetry.device_update_interval);
+        Serial.printf("ModuleConfig:telemetry:environment_display_fahrenheit: %d\r\n", module->payload_variant.telemetry.environment_display_fahrenheit);
+        Serial.printf("ModuleConfig:telemetry:environment_measurement_enabled: %d\r\n", module->payload_variant.telemetry.environment_measurement_enabled);
+        Serial.printf("ModuleConfig:telemetry:environment_screen_enabled: %d\r\n", module->payload_variant.telemetry.environment_screen_enabled);
+        Serial.printf("ModuleConfig:telemetry:environment_update_interval: %d\r\n", module->payload_variant.telemetry.environment_update_interval);
+        Serial.printf("ModuleConfig:telemetry:health_measurement_enabled: %d\r\n", module->payload_variant.telemetry.health_measurement_enabled);
+        Serial.printf("ModuleConfig:telemetry:health_screen_enabled: %d\r\n", module->payload_variant.telemetry.health_screen_enabled);
+        Serial.printf("ModuleConfig:telemetry:health_update_interval: %d\r\n", module->payload_variant.telemetry.health_update_interval);
+        Serial.printf("ModuleConfig:telemetry:power_measurement_enabled: %d\r\n", module->payload_variant.telemetry.power_measurement_enabled);
+        Serial.printf("ModuleConfig:telemetry:power_update_interval: %d\r\n", module->payload_variant.telemetry.power_update_interval);
+
       break;
 
       case meshtastic_ModuleConfig_canned_message_tag: 
+        Serial.printf("ModuleConfig:canned_message:enabled: %d\r\n", module->payload_variant.canned_message.enabled);
+        Serial.printf("ModuleConfig:canned_message:allow_input_source: %d\r\n", module->payload_variant.canned_message.allow_input_source);
+        Serial.printf("ModuleConfig:canned_message:inputbroker_event_ccw: %d\r\n", module->payload_variant.canned_message.inputbroker_event_ccw);
+        Serial.printf("ModuleConfig:canned_message:inputbroker_event_cw: %d\r\n", module->payload_variant.canned_message.inputbroker_event_cw);
+        Serial.printf("ModuleConfig:canned_message:inputbroker_event_pass: %d\r\n", module->payload_variant.canned_message.inputbroker_event_press);
+        Serial.printf("ModuleConfig:canned_message:inputbroker_pin_a: %d\r\n", module->payload_variant.canned_message.inputbroker_pin_a);
+        Serial.printf("ModuleConfig:canned_message:inputbroker_pin_b: %d\r\n", module->payload_variant.canned_message.inputbroker_pin_b);
+        Serial.printf("ModuleConfig:canned_message:inputbroker_pin_press: %d\r\n", module->payload_variant.canned_message.inputbroker_pin_press);
+        Serial.printf("ModuleConfig:canned_message:rotary1_enabled: %d\r\n", module->payload_variant.canned_message.rotary1_enabled);
+        Serial.printf("ModuleConfig:canned_message:send_bell: %d\r\n", module->payload_variant.canned_message.send_bell);
+        Serial.printf("ModuleConfig:canned_message:updown1_enabled: %d\r\n", module->payload_variant.canned_message.updown1_enabled);
       break;
 
       case meshtastic_ModuleConfig_audio_tag: 
+        Serial.printf("ModuleConfig:audio:codec2_enabled: %d\r\n", module->payload_variant.audio.codec2_enabled);
+        Serial.printf("ModuleConfig:audio:bitrate: %d\r\n", module->payload_variant.audio.bitrate);
+        Serial.printf("ModuleConfig:audio:i2s_din: %d\r\n", module->payload_variant.audio.i2s_din);
+        Serial.printf("ModuleConfig:audio:i2s_sck: %d\r\n", module->payload_variant.audio.i2s_sck);
+        Serial.printf("ModuleConfig:audio:i2s_sd: %d\r\n", module->payload_variant.audio.i2s_sd);
+        Serial.printf("ModuleConfig:audio:i2s_ws: %d\r\n", module->payload_variant.audio.i2s_ws);
+        Serial.printf("ModuleConfig:audio:ptt_pin: %d\r\n", module->payload_variant.audio.ptt_pin);
       break;
 
       case meshtastic_ModuleConfig_remote_hardware_tag: 
+        Serial.printf("ModuleConfig:remote_hardware:enabled: %d\r\n", module->payload_variant.remote_hardware.enabled);
+        Serial.printf("ModuleConfig:remote_hardware:allow_undefined_pin_access: %d\r\n", module->payload_variant.remote_hardware.allow_undefined_pin_access);
+        Serial.printf("ModuleConfig:remote_hardware:available_pins: %d\r\n", module->payload_variant.remote_hardware.available_pins);
+        Serial.printf("ModuleConfig:remote_hardware:available_pins_count: %d\r\n", module->payload_variant.remote_hardware.available_pins_count);
+
       break;
 
       case meshtastic_ModuleConfig_neighbor_info_tag: 
+        Serial.printf("ModuleConfig:neighbor_info:enabled: %d\r\n", module->payload_variant.neighbor_info.enabled);
+        Serial.printf("ModuleConfig:neighbor_info:transmit_over_lora: %d\r\n", module->payload_variant.neighbor_info.transmit_over_lora);
+        Serial.printf("ModuleConfig:neighbor_info:update_interval: %d\r\n", module->payload_variant.neighbor_info.update_interval);
       break;
 
       case meshtastic_ModuleConfig_ambient_lighting_tag:
+        Serial.printf("ModuleConfig:ambient_lighting:led_state: %d\r\n", module->payload_variant.ambient_lighting.led_state);
+        Serial.printf("ModuleConfig:ambient_lighting:current: %d\r\n", module->payload_variant.ambient_lighting.current);
+        Serial.printf("ModuleConfig:ambient_lighting:red: %d\r\n", module->payload_variant.ambient_lighting.red);
+        Serial.printf("ModuleConfig:ambient_lighting:green: %d\r\n", module->payload_variant.ambient_lighting.green);
+        Serial.printf("ModuleConfig:ambient_lighting:blue: %d\r\n", module->payload_variant.ambient_lighting.blue);
       break;
 
       case meshtastic_ModuleConfig_detection_sensor_tag: 
+        Serial.printf("ModuleConfig:detection_sensor:enabled: %d\r\n", module->payload_variant.detection_sensor.enabled);
+        Serial.printf("ModuleConfig:detection_sensor:detection_trigger_type: %d\r\n", module->payload_variant.detection_sensor.detection_trigger_type);
+        Serial.printf("ModuleConfig:detection_sensor:min_broadcast_secs: %d\r\n", module->payload_variant.detection_sensor.minimum_broadcast_secs);
+        Serial.printf("ModuleConfig:detection_sensor:monitor_pin: %d\r\n", module->payload_variant.detection_sensor.monitor_pin);
+        Serial.printf("ModuleConfig:detection_sensor:name: %d\r\n", module->payload_variant.detection_sensor.name);
+        Serial.printf("ModuleConfig:detection_sensor:send_bell: %d\r\n", module->payload_variant.detection_sensor.send_bell);
+        Serial.printf("ModuleConfig:detection_sensor:state_broadcast_secs: %d\r\n", module->payload_variant.detection_sensor.state_broadcast_secs);
+        Serial.printf("ModuleConfig:detection_sensor:use_pullup: %d\r\n", module->payload_variant.detection_sensor.use_pullup);
       break;
 
       case meshtastic_ModuleConfig_paxcounter_tag:
+        Serial.printf("ModuleConfig:paxcounter:enabled: %d\r\n", module->payload_variant.paxcounter.enabled);
+        Serial.printf("ModuleConfig:paxcounter:ble_threshold: %d\r\n", module->payload_variant.paxcounter.ble_threshold);
+        Serial.printf("ModuleConfig:paxcounter:paxcounter_update_interval: %d\r\n", module->payload_variant.paxcounter.paxcounter_update_interval);
+        Serial.printf("ModuleConfig:paxcounter:wifi_threshold: %d\r\n", module->payload_variant.paxcounter.wifi_threshold);
       break;
 
       default:
@@ -324,27 +440,52 @@ bool handle_moduleConfig_tag(meshtastic_ModuleConfig *module){
 }
 
 bool handle_queueStatus_tag(meshtastic_QueueStatus *qstatus) {
-  Serial.printf("Handle_queueStatus_tag maxlen: %d\r\n", qstatus->maxlen);
+  Serial.printf("queueStatus: maxlen: %d\r\n", qstatus->maxlen);
+  Serial.printf("queueStatus: res: %d\r\n", qstatus->res);
+  Serial.printf("queueStatus: free: %d\r\n", qstatus->free);
+  Serial.printf("queueStatus: mesh_packet_id: %d\r\n", qstatus->mesh_packet_id);
   return true;
 }
 
 bool handle_xmodemPacket_tag(meshtastic_XModem *packet) {
-  Serial.printf("Handle_xmodem_tag XModem Sequence # %d\r\n", packet->seq);
+  Serial.printf("XmodemPacket: XModem control #: %d\r\n", packet->control);
+  Serial.printf("XmodemPacket: XModem sequence #: %d\r\n", packet->seq);
+  Serial.printf("XmodemPacket: XModem crc16: %d\r\n", packet->crc16);
   return true;
 }
 
 bool handle_metatag_data(meshtastic_DeviceMetadata *meta) {
-  Serial.printf("Handle_metatag_data FW Version: %s\r\n", meta->firmware_version);
+  Serial.printf("metatag_data:FW Version: %s\r\n", meta->firmware_version);
+  Serial.printf("metatag_data:device_state_version: %d\r\n", meta->device_state_version);
+  Serial.printf("metatag_data:canShutdown: %d\r\n", meta->canShutdown);
+  Serial.printf("metatag_data:hasWiFi: %d\r\n", meta->hasWifi);
+  Serial.printf("metatag_data:hasBluetooth: %d\r\n", meta->hasBluetooth);
+  Serial.printf("metatag_data:hasEthernet: %d\r\n", meta->hasEthernet);
+  Serial.printf("metatag_data:role: %d\r\n", meta->role);
+  Serial.printf("metatag_data:positionFlags: %d\r\n", meta->position_flags);
+  Serial.printf("metatag_data:hw_model: %d\r\n", meta->hw_model);
+  Serial.printf("metatag_data:hasRemoteHardware: %d\r\n", meta->hasRemoteHardware);
+  Serial.printf("metatag_data:excludedModules: %d\r\n", meta->excluded_modules);
   return true;
 }
 
 bool handle_mqttClientProxyMessage_tag(meshtastic_MqttClientProxyMessage *mqtt) {
-  Serial.printf("Handle_mqttClientProxyMessage_tag Topic: %s\r\n", mqtt->topic);
+  Serial.printf("mqttClientProxyMessage:Topic: %s\r\n", mqtt->topic);
+  switch (mqtt->which_payload_variant) {
+    case meshtastic_MqttClientProxyMessage_data_tag:
+      // TODO - INVALID Serial.printf("mqttClientProxyMessage:data: %s\r\n", mqtt->payload_variant.data);
+      break;
+    case meshtastic_MqttClientProxyMessage_text_tag:
+      Serial.printf("mqttClientProxyMessage:text %s\r\n", mqtt->payload_variant.text);
+      break;
+  }
+  Serial.printf("mqttClientProxyMessage:retained: %d\r\n", mqtt->retained);
   return true;
 }
 
 bool handle_fileInfo_tag(meshtastic_FileInfo *fInfo) {
-  Serial.printf("Handle_fileInfo_tag FileName: %s\r\n", fInfo->file_name);
+  Serial.printf("fileInfo:fileName: %s\r\n", fInfo->file_name);
+  Serial.printf("fileInfo:sizeBytes: %d\r\n", fInfo->size_bytes);
   return true;
 }
 

--- a/src/mt_serial.cpp
+++ b/src/mt_serial.cpp
@@ -32,12 +32,12 @@ bool mt_serial_send_radio(const char * buf, size_t len) {
   size_t wrote = serial->write(buf, len);
   if (wrote == len) return true;
 
-  if (mt_debugging) {
+#ifdef MT_DEBUGGING
     Serial.print("Tried to send radio ");
     Serial.print(len);
     Serial.print(" but actually sent ");
     Serial.println(wrote);
-  }
+#endif
 
   return false;
 }

--- a/src/mt_wifi.cpp
+++ b/src/mt_wifi.cpp
@@ -99,7 +99,9 @@ bool mt_wifi_loop(uint32_t now) {
       // We just connected to WiFi! Now try to make a TCP connection. If it fails, nobody's
       // actually noticing, but we'll time out soon enough when no packets come in, and then
       // we'll try again from the beginning.
-      if (mt_debugging) print_wifi_status();
+#ifdef MT_DEBUGGING	
+	  print_wifi_status();
+#endif
       mt_wifi_reset_idle_timeout(now);
       open_tcp_connection();
       return can_send;
@@ -117,10 +119,10 @@ bool mt_wifi_loop(uint32_t now) {
     default:
       // None of these should ever happen. If they do, let me know what led to them and I'll
       // update this switch statement.
-      if (mt_debugging) {
+#if MT_DEBUGGING
         Serial.print("Unknown WiFi status ");
         Serial.println(wifi_status);
-      }
+#endif
       while(true);
   }
 }
@@ -162,12 +164,12 @@ bool mt_wifi_send_radio(const char * buf, size_t len) {
   size_t wrote = client.write(buf, len);
   if (wrote == len) return true;
 
-  if (mt_debugging) {
+#ifdef MT_DEBUGGING
     Serial.print("Tried to send radio ");
     Serial.print(len);
     Serial.print(" but actually sent ");
     Serial.println(wrote);
-  }
+#endif
   client.stop();
   return false;
 }


### PR DESCRIPTION
- added additional callbacks for encrypted and non-TEXT portNums
- added robust serial output for incoming packets for information visibility on packets for all PortNum and subvariants

