### PR TITLE
Add a delay to mt_serial_init

### DIFF
--- a/src/mt_serial.cpp
+++ b/src/mt_serial.cpp
@@ -12,7 +12,7 @@
 #endif
 
 void mt_serial_init(int8_t rx_pin, int8_t tx_pin, uint32_t baud) {
-
+delay(4000);                    //Needed to allow for firmware of lora device to boot up 
 // Platform specific: init serial
 #if defined(ARDUINO_ARCH_SAMD)
   serial->begin(baud);


### PR DESCRIPTION
## Serial Connection Fix

While using the client library, I experienced issues where a successful serial connection would not be established.  
To solve this, I added a short 4-second delay at the beginning of the `mt_serial_init()` function:

```cpp
void mt_serial_init(int8_t rx_pin, int8_t tx_pin, uint32_t baud) {
    delay(4000);  // Needed to allow the LoRa device firmware to boot up
    // Serial initialization follows...
}
