### PR TITLE
Expose is_favorite flag

### DIFF
--- a/src/Meshtastic.h
+++ b/src/Meshtastic.h
@@ -21,6 +21,7 @@ extern uint32_t my_node_num;
 typedef struct {
   uint32_t node_num;
   bool is_mine;
+  bool is_favorite;
   bool has_user;
   char user_id[MAX_USER_ID_LEN];
   char long_name[MAX_LONG_NAME_LEN];

--- a/src/mt_protocol.cpp
+++ b/src/mt_protocol.cpp
@@ -514,6 +514,7 @@ bool handle_node_info(meshtastic_NodeInfo *nodeInfo) {
   node.node_num = nodeInfo->num;
   node.is_mine = nodeInfo->num == my_node_num;
   node.last_heard_from = nodeInfo->last_heard;
+  node.is_favorite = nodeInfo->is_favorite;
   node.has_user = nodeInfo->has_user;
   if (node.has_user) {
     memcpy(node.user_id, nodeInfo->user.id, MAX_USER_ID_LEN);


### PR DESCRIPTION
Expose the `is_favorite` flag to arduino projects.

I my project, I use it to early drop all messages except from my own known nodes of the attached meshtastic device. I am confident this could be useful to others.